### PR TITLE
Add base text color to default attributes

### DIFF
--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -154,6 +154,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
         guard let textView = textView else { return }
         textView.addAttributes([
             .font: font,
+            .foregroundColor: theme.text,
             .baselineOffset: baselineOffset
         ], range: .init(0..<textView.string.count))
     }


### PR DESCRIPTION
# Description

Adds the default text color to the default attributes applied to text in the editor. Fixes an issue where the base text color wouldn't change when changing themes.

# Issues
- #713 in [CodeEdit](https://github.com/CodeEditApp/CodeEdit/issues/713)

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested