### PR TITLE
chore: added `CaptureNames` enum, added tests

### DIFF
--- a/Sources/CodeEditTextView/STTextViewController+CaptureNames.swift
+++ b/Sources/CodeEditTextView/STTextViewController+CaptureNames.swift
@@ -1,0 +1,43 @@
+//
+//  STTextViewController+CaptureNames.swift
+//  CodeEditTextView
+//
+//  Created by Lukas Pistrol on 16.08.22.
+//
+
+import Foundation
+
+internal extension STTextViewController {
+    
+    /// A collection of possible capture names for `tree-sitter` with their respected raw values.
+    enum CaptureNames: String, CaseIterable {
+        case include
+        case constructor
+        case keyword
+        case boolean
+        case `repeat`
+        case conditional
+        case tag
+        case comment
+        case variable
+        case property
+        case function
+        case method
+        case number
+        case float
+        case string
+        case type
+        case parameter
+        case typeAlternate = "type_alternate"
+        case variableBuiltin = "variable.builtin"
+        case keywordReturn = "keyword.return"
+        case keywordFunction = "keyword.function"
+
+        /// Returns a specific capture name case from a given string.
+        /// - Parameter string: A string to get the capture name from
+        /// - Returns: A `CaptureNames` case
+        static func fromString(_ string: String?) -> CaptureNames? {
+            allCases.first { $0.rawValue == string }
+        }
+    }
+}

--- a/Sources/CodeEditTextView/STTextViewController+CaptureNames.swift
+++ b/Sources/CodeEditTextView/STTextViewController+CaptureNames.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 internal extension STTextViewController {
-    
+
     /// A collection of possible capture names for `tree-sitter` with their respected raw values.
     enum CaptureNames: String, CaseIterable {
         case include

--- a/Sources/CodeEditTextView/STTextViewController+TreeSitter.swift
+++ b/Sources/CodeEditTextView/STTextViewController+TreeSitter.swift
@@ -77,22 +77,20 @@ internal extension STTextViewController {
     /// - Parameter capture: The capture name
     /// - Returns: A `NSColor`
     func colorForCapture(_ capture: String?) -> NSColor {
-        let colors = theme
-        switch capture {
-        case "include", "constructor", "keyword", "boolean", "variable.builtin",
-            "keyword.return", "keyword.function", "repeat", "conditional", "tag":
-            return colors.keywords
-        case "comment": return colors.comments
-        case "variable", "property": return colors.variables
-        case "function", "method": return colors.variables
-        case "number", "float": return colors.numbers
-        case "string": return colors.strings
-        case "type": return colors.types
-        case "parameter": return colors.variables
-        case "type_alternate": return colors.attributes
-        default:
-            //            print(capture)
-            return colors.text
+        let captureName = CaptureNames.fromString(capture)
+        switch captureName {
+        case .include, .constructor, .keyword, .boolean, .variableBuiltin,
+                .keywordReturn, .keywordFunction, .repeat, .conditional, .tag:
+            return theme.keywords
+        case .comment: return theme.comments
+        case .variable, .property: return theme.variables
+        case .function, .method: return theme.variables
+        case .number, .float: return theme.numbers
+        case .string: return theme.strings
+        case .type: return theme.types
+        case .parameter: return theme.variables
+        case .typeAlternate: return theme.attributes
+        default: return theme.text
         }
     }
 }

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import CodeEditTextView
+import SwiftTreeSitter
+
+final class STTextViewControllerTests: XCTestCase {
+
+    var controller: STTextViewController!
+    var theme: EditorTheme!
+
+    override func setUpWithError() throws {
+        theme = EditorTheme(
+            text: .textColor,
+            insertionPoint: .textColor,
+            invisibles: .gray,
+            background: .textBackgroundColor,
+            lineHighlight: .highlightColor,
+            selection: .selectedTextColor,
+            keywords: .systemPink,
+            commands: .systemBlue,
+            types: .systemMint,
+            attributes: .systemTeal,
+            variables: .systemCyan,
+            values: .systemOrange,
+            numbers: .systemYellow,
+            strings: .systemRed,
+            characters: .systemRed,
+            comments: .systemGreen
+        )
+        controller = STTextViewController(
+            text: .constant(""),
+            language: .default,
+            font: .monospacedSystemFont(ofSize: 11, weight: .medium),
+            theme: theme,
+            tabWidth: 4
+        )
+    }
+
+    func test_captureNames() throws {
+        // test for "keyword"
+        let captureName1 = "keyword"
+        let color1 = controller.colorForCapture(captureName1)
+        XCTAssertEqual(color1, .systemPink)
+
+        // test for "comment"
+        let captureName2 = "comment"
+        let color2 = controller.colorForCapture(captureName2)
+        XCTAssertEqual(color2, .systemGreen)
+
+        /* ... additional tests here ... */
+
+        // test for empty case
+        let captureName3 = ""
+        let color3 = controller.colorForCapture(captureName3)
+        XCTAssertEqual(color3, .textColor)
+
+        // test for random case
+        let captureName4 = "abc123"
+        let color4 = controller.colorForCapture(captureName4)
+        XCTAssertEqual(color4, .textColor)
+    }
+
+}


### PR DESCRIPTION
Using enum cases instead of string literals now when getting a theme color for a capture name.

Related Issue:
- #28 