### PR TITLE
[chore]: Update docs, test cases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/STTextView", branch: "main"),
-        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.6.0"),
+        .package(url: "https://github.com/krzyzanowskim/STTextView", exact: "0.0.20"),
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", exact: "0.6.1"),
         .package(url: "https://github.com/lukepistrol/tree-sitter-bash.git", branch: "feature/spm"),
         .package(url: "https://github.com/tree-sitter/tree-sitter-c.git", branch: "master"),
         .package(url: "https://github.com/tree-sitter/tree-sitter-cpp.git", branch: "master"),

--- a/Sources/CodeEditTextView/Documentation.docc/Add-Languages.md
+++ b/Sources/CodeEditTextView/Documentation.docc/Add-Languages.md
@@ -204,3 +204,7 @@ When everything is working correctly push your `tree-sitter-{lang}` changes to `
 > Take [this PR description](https://github.com/tree-sitter/tree-sitter-javascript/pull/223) as a template and cross-reference it with your Pull Request.
 
 Now you can remove the local dependencies and replace it with the actual package URLs and submit a Pull Request for ``CodeEditTextView``.
+
+## Documentation
+
+Please make sure to add the newly created properties to the documentation `*.md` files.

--- a/Sources/CodeEditTextView/Documentation.docc/CodeLanguage.md
+++ b/Sources/CodeEditTextView/Documentation.docc/CodeLanguage.md
@@ -37,6 +37,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - Rust
 - Swift
 - YAML
+- Zig
 
 ## Topics
 
@@ -77,6 +78,7 @@ let language = CodeLanguage.detectLanguageFrom(url: fileURL)
 - ``rust``
 - ``swift``
 - ``yaml``
+- ``zig``
 
 ### Type Methods
 

--- a/Sources/CodeEditTextView/Documentation.docc/TreeSitterModel.md
+++ b/Sources/CodeEditTextView/Documentation.docc/TreeSitterModel.md
@@ -50,3 +50,4 @@ let query = TreeSitterModel.shared.swiftQuery
 - ``rustQuery``
 - ``swiftQuery``
 - ``yamlQuery``
+- ``zigQuery``

--- a/Tests/CodeEditTextViewTests/CodeEditTextViewTests.swift
+++ b/Tests/CodeEditTextViewTests/CodeEditTextViewTests.swift
@@ -238,6 +238,15 @@ final class CodeEditTextViewTests: XCTestCase {
         XCTAssertEqual(language.id, .yaml)
     }
 
+    // MARK: Zig
+
+    func test_CodeLanguageZig() throws {
+        let url = URL(fileURLWithPath: "~/path/to/file.zig")
+        let language = CodeLanguage.detectLanguageFrom(url: url)
+
+        XCTAssertEqual(language.id, .zig)
+    }
+
     // MARK: Unsupported
 
     func test_CodeLanguageUnsupported() throws {


### PR DESCRIPTION
- Updated docs for `zig`
- Added test case for `zig`
- fixed version for `STTextView` and `SwiftTreeSitter`. This is done to prevent updating to a new version with breaking changes by accident.