### PR TITLE
[chore]: Actions - Cache Dependencies

### DIFF
--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -17,4 +17,4 @@ set -o pipefail && arch -"${ARCH}" xcodebuild  \
            -scheme CodeEditTextView \
            -derivedDataPath ".build" \
            -destination "platform=macos,arch=${ARCH}" \
-           clean test | xcpretty
+           clean test

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -17,4 +17,4 @@ set -o pipefail && arch -"${ARCH}" xcodebuild  \
            -scheme CodeEditTextView \
            -derivedDataPath ".build" \
            -destination "platform=macos,arch=${ARCH}" \
-           test
+           clean test | xcpretty

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -15,5 +15,6 @@ export LC_CTYPE=en_US.UTF-8
 
 set -o pipefail && arch -"${ARCH}" xcodebuild  \
            -scheme CodeEditTextView \
+           -derivedDataPath ".build" \
            -destination "platform=macos,arch=${ARCH}" \
-           clean test | xcpretty
+           test

--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -17,4 +17,4 @@ set -o pipefail && arch -"${ARCH}" xcodebuild  \
            -scheme CodeEditTextView \
            -derivedDataPath ".build" \
            -destination "platform=macos,arch=${ARCH}" \
-           clean test
+           clean test | xcpretty

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
+      - uses: actions/cache@v3
+        with:
+          path: '.build'
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - uses: fwcd/swift-docc-action@v1.0.2
         with:
           target: CodeEditTextView

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
+      - uses: actions/cache@v3
+        with:
+          path: '.build'
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Make executeable
         run: chmod +x ./.github/scripts/tests.sh
       - name: Testing Package

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .idea/
-Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /*.xcodeproj
 xcuserdata/
 DerivedData/
-.swiftpm/config/registries.json
-.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.swiftpm
 .netrc
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /*.xcodeproj
 xcuserdata/
 DerivedData/
-.swiftpm
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .idea/

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CodeEditTextView.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CodeEditTextView.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CodeEditTextView"
+               BuildableName = "CodeEditTextView"
+               BlueprintName = "CodeEditTextView"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CodeEditTextViewTests"
+               BuildableName = "CodeEditTextViewTests"
+               BlueprintName = "CodeEditTextViewTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CodeEditTextViewTests"
+               BuildableName = "CodeEditTextViewTests"
+               BlueprintName = "CodeEditTextViewTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CodeEditTextView"
+            BuildableName = "CodeEditTextView"
+            BlueprintName = "CodeEditTextView"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/SwiftTreeSitter",
       "state" : {
-        "revision" : "824aa62ccfeb9bed62a6abd42ba1f06f9a75e99c",
-        "version" : "0.6.1"
+        "branch" : "main",
+        "revision" : "8f903d0f9f88075398bb5e9e300195b688324724"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,212 @@
+{
+  "pins" : [
+    {
+      "identity" : "sttextview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/STTextView",
+      "state" : {
+        "revision" : "9174178a128cc23c569596f400d3cd7e658c197b",
+        "version" : "0.0.20"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swifttreesitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter",
+      "state" : {
+        "revision" : "824aa62ccfeb9bed62a6abd42ba1f06f9a75e99c",
+        "version" : "0.6.1"
+      }
+    },
+    {
+      "identity" : "tree-sitter-bash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/tree-sitter-bash.git",
+      "state" : {
+        "branch" : "feature/spm",
+        "revision" : "13af3b5b2c40d560aefeac28361d64f525d1869f"
+      }
+    },
+    {
+      "identity" : "tree-sitter-c",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-c.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "3ced8d6cd212a6f576cd4ef3d533bcb9c09eface"
+      }
+    },
+    {
+      "identity" : "tree-sitter-c-sharp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-c-sharp.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "49716ffc113a51c567a9442c69b42c7d1fa08c7b"
+      }
+    },
+    {
+      "identity" : "tree-sitter-cpp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-cpp.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "38d8b495bd43977498f0eb122e0f9cfef8526d18"
+      }
+    },
+    {
+      "identity" : "tree-sitter-css",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/tree-sitter-css.git",
+      "state" : {
+        "branch" : "feature/spm",
+        "revision" : "baf1fadcac4f7b7c0f0f273feec4ad68864bc783"
+      }
+    },
+    {
+      "identity" : "tree-sitter-elixir",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/elixir-lang/tree-sitter-elixir.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "3b8eb02597599ee38cfcc2c0fea76dc37a7472eb"
+      }
+    },
+    {
+      "identity" : "tree-sitter-go",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-go.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "aeb2f33b366fd78d5789ff104956ce23508b85db"
+      }
+    },
+    {
+      "identity" : "tree-sitter-go-mod",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/camdencheek/tree-sitter-go-mod.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "4a65743dbc2bb3094114dd2b43da03c820aa5234"
+      }
+    },
+    {
+      "identity" : "tree-sitter-haskell",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-haskell.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "bee6b49543e34c2967c6294a4b05e8bd2bf2da59"
+      }
+    },
+    {
+      "identity" : "tree-sitter-html",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattmassicotte/tree-sitter-html.git",
+      "state" : {
+        "branch" : "feature/spm",
+        "revision" : "68b8bed0c1ebecbaf1919d0a7ae4b27592e6cc45"
+      }
+    },
+    {
+      "identity" : "tree-sitter-java",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-java.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "ac14b4b1884102839455d32543ab6d53ae089ab7"
+      }
+    },
+    {
+      "identity" : "tree-sitter-javascript",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-javascript.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "785831303ce3d36f5dd8ada7c4c7d63518d4d2f5"
+      }
+    },
+    {
+      "identity" : "tree-sitter-json",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattmassicotte/tree-sitter-json.git",
+      "state" : {
+        "branch" : "feature/spm",
+        "revision" : "07fd294fe05a3d726ab9191e504db5f7648fa3fd"
+      }
+    },
+    {
+      "identity" : "tree-sitter-php",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-php.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "6c1edb96fdbce5b44c2ecebe15cf9adfb8fed06a"
+      }
+    },
+    {
+      "identity" : "tree-sitter-python",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/tree-sitter-python.git",
+      "state" : {
+        "branch" : "feature/spm",
+        "revision" : "78ab3c3dd69a571156ffd1c7ace7c49fb2e284ef"
+      }
+    },
+    {
+      "identity" : "tree-sitter-ruby",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattmassicotte/tree-sitter-ruby.git",
+      "state" : {
+        "branch" : "feature/swift",
+        "revision" : "e0923bfc25cadb2d5fd0a07c3b55e4b2d1501cb8"
+      }
+    },
+    {
+      "identity" : "tree-sitter-rust",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-rust.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "36ae187ed6dd3803a8a89dbb54f3124c8ee74662"
+      }
+    },
+    {
+      "identity" : "tree-sitter-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/alex-pinkus/tree-sitter-swift",
+      "state" : {
+        "branch" : "with-generated-files",
+        "revision" : "0abae4d0edc53c882321f85088d435ac4c2fb2cb"
+      }
+    },
+    {
+      "identity" : "tree-sitter-yaml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattmassicotte/tree-sitter-yaml.git",
+      "state" : {
+        "branch" : "feature/spm",
+        "revision" : "bd633dc67bd71934961610ca8bd832bf2153883e"
+      }
+    },
+    {
+      "identity" : "tree-sitter-zig",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/maxxnino/tree-sitter-zig.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "433574f2a086a13cb30463f1f9c72a9be4f88a57"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/SwiftTreeSitter",
       "state" : {
-        "branch" : "main",
-        "revision" : "8f903d0f9f88075398bb5e9e300195b688324724"
+        "branch" : "0.6.1",
+        "revision" : "824aa62ccfeb9bed62a6abd42ba1f06f9a75e99c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/krzyzanowskim/STTextView", exact: "0.0.20"),
-        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", branch: "main"),
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", branch: "0.6.1"),
         .package(url: "https://github.com/lukepistrol/tree-sitter-bash.git", branch: "feature/spm"),
         .package(url: "https://github.com/tree-sitter/tree-sitter-c.git", branch: "master"),
         .package(url: "https://github.com/tree-sitter/tree-sitter-cpp.git", branch: "master"),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/krzyzanowskim/STTextView", exact: "0.0.20"),
-        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", exact: "0.6.1"),
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", branch: "main"),
         .package(url: "https://github.com/lukepistrol/tree-sitter-bash.git", branch: "feature/spm"),
         .package(url: "https://github.com/tree-sitter/tree-sitter-c.git", branch: "master"),
         .package(url: "https://github.com/tree-sitter/tree-sitter-cpp.git", branch: "master"),
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/lukepistrol/tree-sitter-python.git", branch: "feature/spm"),
         .package(url: "https://github.com/mattmassicotte/tree-sitter-ruby.git", branch: "feature/swift"),
         .package(url: "https://github.com/tree-sitter/tree-sitter-rust.git", branch: "master"),
-        .package(url: "https://github.com/alex-pinkus/tree-sitter-swift", branch: "with-generated-files"),
+        .package(url: "https://github.com/alex-pinkus/tree-sitter-swift.git", branch: "with-generated-files"),
         .package(url: "https://github.com/mattmassicotte/tree-sitter-yaml.git", branch: "feature/spm"),
         .package(url: "https://github.com/maxxnino/tree-sitter-zig.git", branch: "main"),
     ],


### PR DESCRIPTION
In order to cut down the time of our CI with Github Actions, dependencies are now cached using [actions/cache](https://github.com/actions/cache).

This action plugin checks `Package.resolved` and when there are no changes, it downloads the cached build folder instead of fetching each dependency one-by-one.

This saves about ~5-7 minutes per test run. Once there are changes in `Package.resolved`, of course, it will result in a longer test run.

![Screen Shot 2022-10-04 at 20 30 23](https://user-images.githubusercontent.com/9460130/193897671-83bb741a-55e0-439e-a6e4-190b78af2e67.png)
