### PR TITLE
remove swift-docc-plugin since it is no longer needed

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swifttreesitter",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/SwiftTreeSitter",

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,6 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/apple/swift-docc-plugin.git",
-            from: "1.0.0"
-        ),
-        .package(
             url: "https://github.com/krzyzanowskim/STTextView.git",
             exact: "0.1.1"
         ),


### PR DESCRIPTION
Since we now use `xcodebuild docbuild` to build DocC documentation, the `swift-docs-plugin` is no longer needed.