### PR TITLE
Change target version of STTextView

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/krzyzanowskim/STTextView.git",
-            exact: "0.1.1"
+            from: "0.1.1"
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",


### PR DESCRIPTION
A bug was fixed at this commit: https://github.com/krzyzanowskim/STTextView/commit/6a3ed085c26ba06fcd365c5056b31755cbddfa87
A release tag need to be created for STTextView, so it's a logic change to target the version of SPM to `from:`