### PR TITLE
Fix for non-updating text

### DIFF
--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -169,6 +169,10 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     public override func viewDidAppear() {
         super.viewDidAppear()
     }
+    
+    public func textDidChange(_ notification: Notification) {
+        self.text.wrappedValue = textView.string
+    }
 
     // MARK: UI
 

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -169,7 +169,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     public override func viewDidAppear() {
         super.viewDidAppear()
     }
-    
+
     public func textDidChange(_ notification: Notification) {
         self.text.wrappedValue = textView.string
     }


### PR DESCRIPTION
This fixes an issue where the text Binding wouldn't update. `CodeEditTextView` would receive updates to input just fine, but the client wouldn't get any updates about the changes in the string.