### PR TITLE
Support a text wrapping preference in the textview

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ An Xcode-inspired code editor view written in Swift powered by tree-sitter for [
 
 <img width="1012" alt="social-cover-textview" src="https://user-images.githubusercontent.com/806104/194083584-91555dce-ad4c-4066-922e-1eab889134be.png">
 
-![Github Tests](https://img.shields.io/github/workflow/status/CodeEditApp/CodeEditTextView/tests/main?label=tests&style=flat-square)
-![Documentation](https://img.shields.io/github/workflow/status/CodeEditApp/CodeEditTextView/build-documentation/main?label=docs&style=flat-square)
+![Github Tests](https://img.shields.io/github/actions/workflow/status/CodeEditApp/CodeEditTextView/tests.yml?branch=main&label=tests&style=flat-square)
+![Documentation](https://img.shields.io/github/actions/workflow/status/CodeEditApp/CodeEditTextView/build-documentation.yml?branch=main&label=docs&style=flat-square)
 ![GitHub Repo stars](https://img.shields.io/github/stars/CodeEditApp/CodeEditTextView?style=flat-square)
 ![GitHub forks](https://img.shields.io/github/forks/CodeEditApp/CodeEditTextView?style=flat-square)
 [![Discord Badge](https://img.shields.io/discord/951544472238444645?color=5865F2&label=Discord&logo=discord&logoColor=white&style=flat-square)](https://discord.gg/vChUXVf9Em)

--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -20,6 +20,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///   - font: The default font
     ///   - tabWidth: The tab width
     ///   - lineHeight: The line height multiplier (e.g. `1.2`)
+    ///   - wrapLines: Whether lines wrap to the width of the editor
+    ///   - wrappedIndent: The number of spaces to indent wrapped lines
     ///   - editorOverscroll: The percentage for overscroll, between 0-1 (default: `0.0`)
     public init(
         _ text: Binding<String>,
@@ -28,6 +30,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         font: Binding<NSFont>,
         tabWidth: Binding<Int>,
         lineHeight: Binding<Double>,
+        wrapLines: Binding<Bool>,
+        wrappedIndent: Binding<Int>,
         editorOverscroll: Binding<Double> = .constant(0.0),
         cursorPosition: Published<(Int, Int)>.Publisher? = nil
     ) {
@@ -37,6 +41,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self._font = font
         self._tabWidth = tabWidth
         self._lineHeight = lineHeight
+        self._wrapLines = wrapLines
+        self._wrappedIndent = wrappedIndent
         self._editorOverscroll = editorOverscroll
         self.cursorPosition = cursorPosition
     }
@@ -47,6 +53,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var font: NSFont
     @Binding private var tabWidth: Int
     @Binding private var lineHeight: Double
+    @Binding private var wrapLines: Bool
+    @Binding private var wrappedIndent: Int
     @Binding private var editorOverscroll: Double
     private var cursorPosition: Published<(Int, Int)>.Publisher?
 
@@ -59,6 +67,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             font: font,
             theme: theme,
             tabWidth: tabWidth,
+            wrapLines: wrapLines,
+            wrappedIndent: wrappedIndent,
             cursorPosition: cursorPosition,
             editorOverscroll: editorOverscroll
         )
@@ -71,6 +81,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         controller.language = language
         controller.theme = theme
         controller.tabWidth = tabWidth
+        controller.wrapLines = wrapLines
+        controller.wrappedIndent = wrappedIndent
         controller.lineHeightMultiple = lineHeight
         controller.editorOverscroll = editorOverscroll
         controller.reloadUI()

--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -21,7 +21,6 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///   - tabWidth: The tab width
     ///   - lineHeight: The line height multiplier (e.g. `1.2`)
     ///   - wrapLines: Whether lines wrap to the width of the editor
-    ///   - wrappedIndent: The number of spaces to indent wrapped lines
     ///   - editorOverscroll: The percentage for overscroll, between 0-1 (default: `0.0`)
     public init(
         _ text: Binding<String>,
@@ -31,7 +30,6 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         tabWidth: Binding<Int>,
         lineHeight: Binding<Double>,
         wrapLines: Binding<Bool>,
-        wrappedIndent: Binding<Int>,
         editorOverscroll: Binding<Double> = .constant(0.0),
         cursorPosition: Published<(Int, Int)>.Publisher? = nil
     ) {
@@ -42,7 +40,6 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self._tabWidth = tabWidth
         self._lineHeight = lineHeight
         self._wrapLines = wrapLines
-        self._wrappedIndent = wrappedIndent
         self._editorOverscroll = editorOverscroll
         self.cursorPosition = cursorPosition
     }
@@ -54,7 +51,6 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var tabWidth: Int
     @Binding private var lineHeight: Double
     @Binding private var wrapLines: Bool
-    @Binding private var wrappedIndent: Int
     @Binding private var editorOverscroll: Double
     private var cursorPosition: Published<(Int, Int)>.Publisher?
 
@@ -68,7 +64,6 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             theme: theme,
             tabWidth: tabWidth,
             wrapLines: wrapLines,
-            wrappedIndent: wrappedIndent,
             cursorPosition: cursorPosition,
             editorOverscroll: editorOverscroll
         )
@@ -82,7 +77,6 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         controller.theme = theme
         controller.tabWidth = tabWidth
         controller.wrapLines = wrapLines
-        controller.wrappedIndent = wrappedIndent
         controller.lineHeightMultiple = lineHeight
         controller.editorOverscroll = editorOverscroll
         controller.reloadUI()

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -95,8 +95,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView.textColor = .systemGray
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
-        rulerView.font = NSFont(descriptor: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular).fontDescriptor, textTransform: AffineTransform(scaleByX: 1, byY: 1.1)) ?? .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
-
+        rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true
 

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -44,7 +44,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
     /// The editorOverscroll to use for the textView over scroll
     public var editorOverscroll: Double
-    
+
     /// Whether lines wrap to the width of the editor
     public var wrapLines: Bool
 
@@ -84,7 +84,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
     public override func loadView() {
         textView = STTextView()
-        
+
         let scrollView = NSScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -83,22 +83,19 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     // MARK: VC Lifecycle
 
     public override func loadView() {
-        let scrollView = STTextView.scrollableTextView()
-        textView = scrollView.documentView as? STTextView
-
-        // By default this is always null but is required for a couple operations
-        // during highlighting so we make a new one manually.
-        // textView.textContainer.replaceLayoutManager(NSLayoutManager())
-
+        textView = STTextView()
+        
+        let scrollView = NSScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true
+        scrollView.documentView = textView
 
         rulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
         rulerView.backgroundColor = theme.background
         rulerView.textColor = .systemGray
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
-        rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
+        rulerView.font = NSFont(descriptor: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular).fontDescriptor, textTransform: AffineTransform(scaleByX: 1, byY: 1.1)) ?? .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
 
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true
@@ -112,7 +109,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView.selectionBackgroundColor = theme.selection
         textView.selectedLineHighlightColor = theme.lineHighlight
         textView.string = self.text.wrappedValue
-        textView.widthTracksTextView = true
+        textView.widthTracksTextView = self.wrapLines
         textView.highlightSelectedLine = true
         textView.allowsUndo = true
         textView.setupMenus()

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -47,9 +47,6 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     
     /// Whether lines wrap to the width of the editor
     public var wrapLines: Bool
-    
-    /// The number of spaces to indent wrapped lines
-    public var wrappedIndent: Int
 
     // MARK: - Highlighting
 
@@ -65,7 +62,6 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         theme: EditorTheme,
         tabWidth: Int,
         wrapLines: Bool,
-        wrappedIndent: Int,
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
         editorOverscroll: Double
     ) {
@@ -75,7 +71,6 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         self.theme = theme
         self.tabWidth = tabWidth
         self.wrapLines = wrapLines
-        self.wrappedIndent = wrappedIndent
         self.cursorPosition = cursorPosition
         self.editorOverscroll = editorOverscroll
         super.init(nibName: nil, bundle: nil)

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -44,6 +44,12 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
     /// The editorOverscroll to use for the textView over scroll
     public var editorOverscroll: Double
+    
+    /// Whether lines wrap to the width of the editor
+    public var wrapLines: Bool
+    
+    /// The number of spaces to indent wrapped lines
+    public var wrappedIndent: Int
 
     // MARK: - Highlighting
 
@@ -58,6 +64,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         font: NSFont,
         theme: EditorTheme,
         tabWidth: Int,
+        wrapLines: Bool,
+        wrappedIndent: Int,
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
         editorOverscroll: Double
     ) {
@@ -66,6 +74,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         self.font = font
         self.theme = theme
         self.tabWidth = tabWidth
+        self.wrapLines = wrapLines
+        self.wrappedIndent = wrappedIndent
         self.cursorPosition = cursorPosition
         self.editorOverscroll = editorOverscroll
         super.init(nibName: nil, bundle: nil)
@@ -83,7 +93,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
         // By default this is always null but is required for a couple operations
         // during highlighting so we make a new one manually.
-        textView.textContainer.replaceLayoutManager(NSLayoutManager())
+        // textView.textContainer.replaceLayoutManager(NSLayoutManager())
 
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -33,6 +33,7 @@ final class STTextViewControllerTests: XCTestCase {
             font: .monospacedSystemFont(ofSize: 11, weight: .medium),
             theme: theme,
             tabWidth: 4,
+            wrapLines: true,
             editorOverscroll: 0.5
         )
     }


### PR DESCRIPTION
# Background
This addresses bug #84 , and fulfills some of the requirements of #66 (the rest of which will be implemented in **CodeEdit** in a nascent PR). 

## Technical Details

Two things to note:

1. This will likely regress highlighting behavior- more detailed discussion available on [this discord channel](https://discord.com/channels/951544472238444645/952640818068463667/1059969085695340595), but TLDR: @thecoolwinter has plans to obviate the need for the removed `NSLayoutManager` code when he migrates that work to TextKit 2.

2. I went ahead and removed the invocation of STTextView's static scrollableTextView() helper function. It sets a number of properties which are immediately overwritten by our code in `loadView()`. It only obfuscates what's really happening here.

