### PR TITLE
Remove `NSLayoutManager`

### DIFF
--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -73,12 +73,19 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
 
     public func updateNSViewController(_ controller: NSViewControllerType, context: Context) {
         controller.font = font
-        controller.language = language
-        controller.theme = theme
         controller.tabWidth = tabWidth
         controller.wrapLines = wrapLines
         controller.lineHeightMultiple = lineHeight
         controller.editorOverscroll = editorOverscroll
+
+        // Updating the language and theme needlessly can cause highlights to be re-calculated.
+        if controller.language.id != language.id {
+            controller.language = language
+        }
+        if controller.theme != theme {
+            controller.theme = theme
+        }
+
         controller.reloadUI()
         return
     }

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+NSTextRange.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+NSTextRange.swift
@@ -21,4 +21,17 @@ public extension NSTextRange {
 
         self.init(location: start, end: end)
     }
+
+    /// Creates an `NSRange` using document information from the given provider.
+    /// - Parameter provider: The `NSTextElementProvider` to use to convert this range into an `NSRange`
+    /// - Returns: An `NSRange` if possible
+    func nsRange(using provider: NSTextElementProvider) -> NSRange? {
+        guard let location = provider.offset?(from: provider.documentRange.location, to: location) else {
+            return nil
+        }
+        guard let length = provider.offset?(from: self.location, to: endLocation) else {
+            return nil
+        }
+        return NSRange(location: location, length: length)
+    }
 }

--- a/Sources/CodeEditTextView/Highlighting/HighlightRange.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlightRange.swift
@@ -1,6 +1,6 @@
 //
 //  HighlightRange.swift
-//  
+//
 //
 //  Created by Khan Winter on 9/14/22.
 //

--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -42,7 +42,10 @@ class Highlighter: NSObject {
 
     /// The set of visible indexes in tht text view
     lazy private var visibleSet: IndexSet = {
-        return IndexSet(integersIn: Range(textView.visibleTextRange)!)
+        guard let range = textView.visibleTextRange else {
+            return IndexSet()
+        }
+        return IndexSet(integersIn: Range(range)!)
     }()
 
     // MARK: - UI
@@ -184,6 +187,11 @@ private extension Highlighter {
             // Loop through each highlight and modify the textStorage accordingly.
             textView.textContentStorage.textStorage?.beginEditing()
             for highlight in highlightRanges {
+                // Does not work:
+//                textView.textLayoutManager.setRenderingAttributes(attributeProvider.attributesFor(highlight.capture),
+//                                                                  for: NSTextRange(highlight.range,
+//                                                                       provider: textView.textContentStorage)!)
+                // Temp solution (until Apple fixes above)
                 textView.textContentStorage.textStorage?.setAttributes(
                     attributeProvider.attributesFor(highlight.capture),
                     range: highlight.range
@@ -219,7 +227,7 @@ private extension Highlighter {
 private extension Highlighter {
     /// Updates the view to highlight newly visible text when the textview is scrolled or bounds change.
     @objc func visibleTextChanged(_ notification: Notification) {
-        visibleSet = IndexSet(integersIn: Range(textView.visibleTextRange)!)
+        visibleSet = IndexSet(integersIn: Range(textView.visibleTextRange ?? NSRange())!)
 
         // Any indices that are both *not* valid and in the visible text range should be invalidated
         let newlyInvalidSet = visibleSet.subtracting(validSet)


### PR DESCRIPTION
# Description

This PR removes all references to `NSLayoutManager` and fixes syntax highlighting after the regression in #105.

# Related Issues

N/A

# Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested