### PR TITLE
Set `scrollView` background color

### DIFF
--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -17,6 +17,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
     internal var textView: STTextView!
 
+    internal var scrollView: NSScrollView!
+
     internal var rulerView: STLineNumberRulerView!
 
     /// Binding for the `textView`s string
@@ -85,7 +87,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     public override func loadView() {
         textView = STTextView()
 
-        let scrollView = NSScrollView()
+        scrollView = NSScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true
         scrollView.documentView = textView
@@ -210,6 +212,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView?.backgroundColor = theme.background
         rulerView?.separatorColor = theme.invisibles
         rulerView?.baselineOffset = baselineOffset
+
+        scrollView?.backgroundColor = theme.background
 
         (view as? NSScrollView)?.contentView.contentInsets.bottom = bottomContentInsets
 

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -17,8 +17,6 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
     internal var textView: STTextView!
 
-    internal var scrollView: NSScrollView!
-
     internal var rulerView: STLineNumberRulerView!
 
     /// Binding for the `textView`s string
@@ -87,7 +85,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     public override func loadView() {
         textView = STTextView()
 
-        scrollView = NSScrollView()
+        let scrollView = NSScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true
         scrollView.documentView = textView
@@ -213,8 +211,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView?.separatorColor = theme.invisibles
         rulerView?.baselineOffset = baselineOffset
 
-        scrollView?.backgroundColor = theme.background
-
+        (view as? NSScrollView)?.backgroundColor = theme.background
         (view as? NSScrollView)?.contentView.contentInsets.bottom = bottomContentInsets
 
         setStandardAttributes()


### PR DESCRIPTION
# Description 

Updates the scroll view's background color to the theme's background color to avoid ugly edges on scroll.

**Before**

https://user-images.githubusercontent.com/35942988/211999177-5a11f56b-3cfd-44d2-95f5-b866ae276e98.mov

**After**

https://user-images.githubusercontent.com/35942988/211999157-b3926ec5-0115-4545-9b4a-728f7f79771f.mov

# Related Issues

N/A
