### PR TITLE
Highlight Ignored Indexes

### DIFF
--- a/Sources/CodeEditTextView/Extensions/IndexSet+NSRange.swift
+++ b/Sources/CodeEditTextView/Extensions/IndexSet+NSRange.swift
@@ -1,0 +1,38 @@
+//
+//  IndexSet+NSRange.swift
+//  
+//
+//  Created by Khan Winter on 1/12/23.
+//
+
+import Foundation
+
+extension NSRange {
+    /// Convenience getter for safely creating a `Range<Int>` from an `NSRange`
+    var intRange: Range<Int> {
+        self.location..<NSMaxRange(self)
+    }
+}
+
+/// Helpers for working with `NSRange`s and `IndexSet`s.
+extension IndexSet {
+    /// Initializes the  index set with a range of integers
+    init(integersIn range: NSRange) {
+        self.init(integersIn: range.intRange)
+    }
+
+    /// Remove all the integers in the `NSRange`
+    mutating func remove(integersIn range: NSRange) {
+        self.remove(integersIn: range.intRange)
+    }
+
+    /// Insert all the integers in the `NSRange`
+    mutating func insert(integersIn range: NSRange) {
+        self.insert(integersIn: range.intRange)
+    }
+
+    /// Returns true if self contains all of the integers in range.
+    func contains(integersIn range: NSRange) -> Bool {
+        return self.contains(integersIn: range.intRange)
+    }
+}


### PR DESCRIPTION
# Description

Tracks indexes that were not given an explicit color and highlights them as normal text. This fixes problems where certain characters would change color (eg: they were put in a comment) and then need to change back, but were skipped.

This also fixes the problem in #99 where text was not given an explicit highlight on paste. [Since `STTextView` does not add default attributes to pasted text by default](https://github.com/krzyzanowskim/STTextView/blob/5d137731401d12412d567244facf086c325ff95b/Sources/STTextView/STTextView%2BCopyPaste.swift#L26) (see the `useTypingAttributes: false` in that method call).

Doing this also seems to have an effect on the annoying glitching that was caused when entering text in an empty line (see the comment screen recording)

This PR also adds a helper for converting from an `NSRange` to a `Range<Int>` and gets rid of a bunch of ugly force unwraps that existed before. It also adds some convenience methods for modifying `IndexSet`s using indexes from `NSRange` objects.

# Related Issues

- #99 

# UI Fixes

### Paste Text (Old)

https://user-images.githubusercontent.com/35942988/212186310-ee50dcaa-ebec-4e21-905b-562fc2cdf940.mov

### Paste Text (new)

https://user-images.githubusercontent.com/35942988/212186342-402ceb89-2122-4431-88ac-2363e6452323.mov

### Multi-Line comment (old)

https://user-images.githubusercontent.com/35942988/212186411-dc77744f-270b-4615-80c6-ed02e7c38e80.mov

### Multi-Line comment (new)

https://user-images.githubusercontent.com/35942988/212186437-ba014944-fa6c-4de9-8ad3-c8105a655418.mov

Closes #99 