### PR TITLE
Theme background

### DIFF
--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -27,18 +27,18 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         _ text: Binding<String>,
         language: CodeLanguage,
         theme: Binding<EditorTheme>,
-        useThemeBackground: Binding<Bool>,
         font: Binding<NSFont>,
         tabWidth: Binding<Int>,
         lineHeight: Binding<Double>,
         wrapLines: Binding<Bool>,
         editorOverscroll: Binding<Double> = .constant(0.0),
-        cursorPosition: Published<(Int, Int)>.Publisher? = nil
+        cursorPosition: Published<(Int, Int)>.Publisher? = nil,
+        useThemeBackground: Bool = true
     ) {
         self._text = text
         self.language = language
         self._theme = theme
-        self._useThemeBackground = useThemeBackground
+        self.useThemeBackground = useThemeBackground
         self._font = font
         self._tabWidth = tabWidth
         self._lineHeight = lineHeight
@@ -50,13 +50,13 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var text: String
     private var language: CodeLanguage
     @Binding private var theme: EditorTheme
-    @Binding private var useThemeBackground: Bool
     @Binding private var font: NSFont
     @Binding private var tabWidth: Int
     @Binding private var lineHeight: Double
     @Binding private var wrapLines: Bool
     @Binding private var editorOverscroll: Double
     private var cursorPosition: Published<(Int, Int)>.Publisher?
+    private var useThemeBackground: Bool
 
     public typealias NSViewControllerType = STTextViewController
 
@@ -66,11 +66,11 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             language: language,
             font: font,
             theme: theme,
-            useThemeBackground: useThemeBackground,
             tabWidth: tabWidth,
             wrapLines: wrapLines,
             cursorPosition: cursorPosition,
-            editorOverscroll: editorOverscroll
+            editorOverscroll: editorOverscroll,
+            useThemeBackground: useThemeBackground
         )
         controller.lineHeightMultiple = lineHeight
         return controller

--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -17,6 +17,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///   - text: The text content
     ///   - language: The language for syntax highlighting
     ///   - theme: The theme for syntax highlighting
+    ///   - useThemeBackground: Whether CodeEditTextView uses theme background color or is transparent
     ///   - font: The default font
     ///   - tabWidth: The tab width
     ///   - lineHeight: The line height multiplier (e.g. `1.2`)
@@ -26,6 +27,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         _ text: Binding<String>,
         language: CodeLanguage,
         theme: Binding<EditorTheme>,
+        useThemeBackground: Binding<Bool>,
         font: Binding<NSFont>,
         tabWidth: Binding<Int>,
         lineHeight: Binding<Double>,
@@ -36,6 +38,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self._text = text
         self.language = language
         self._theme = theme
+        self._useThemeBackground = useThemeBackground
         self._font = font
         self._tabWidth = tabWidth
         self._lineHeight = lineHeight
@@ -47,6 +50,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var text: String
     private var language: CodeLanguage
     @Binding private var theme: EditorTheme
+    @Binding private var useThemeBackground: Bool
     @Binding private var font: NSFont
     @Binding private var tabWidth: Int
     @Binding private var lineHeight: Double
@@ -62,6 +66,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             language: language,
             font: font,
             theme: theme,
+            useThemeBackground: useThemeBackground,
             tabWidth: tabWidth,
             wrapLines: wrapLines,
             cursorPosition: cursorPosition,
@@ -75,6 +80,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         controller.font = font
         controller.tabWidth = tabWidth
         controller.wrapLines = wrapLines
+        controller.useThemeBackground = useThemeBackground
         controller.lineHeightMultiple = lineHeight
         controller.editorOverscroll = editorOverscroll
 

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -33,6 +33,9 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         highlighter?.invalidate()
     }}
 
+    /// Whether the code editor should use the theme background color or be transparent
+    public var useThemeBackground: Bool
+
     /// The number of spaces to use for a `tab '\t'` character
     public var tabWidth: Int
 
@@ -60,6 +63,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         language: CodeLanguage,
         font: NSFont,
         theme: EditorTheme,
+        useThemeBackground: Bool,
         tabWidth: Int,
         wrapLines: Bool,
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
@@ -69,6 +73,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         self.language = language
         self.font = font
         self.theme = theme
+        self.useThemeBackground = useThemeBackground
         self.tabWidth = tabWidth
         self.wrapLines = wrapLines
         self.cursorPosition = cursorPosition
@@ -89,9 +94,10 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true
         scrollView.documentView = textView
+        scrollView.drawsBackground = useThemeBackground
 
         rulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
-        rulerView.backgroundColor = theme.background
+        rulerView.backgroundColor = useThemeBackground ? theme.background : .clear
         rulerView.textColor = .systemGray
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
@@ -102,7 +108,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView.defaultParagraphStyle = self.paragraphStyle
         textView.font = self.font
         textView.textColor = theme.text
-        textView.backgroundColor = theme.background
+        textView.backgroundColor = useThemeBackground ? theme.background : .clear
         textView.insertionPointColor = theme.insertionPoint
         textView.insertionPointWidth = 1.0
         textView.selectionBackgroundColor = theme.selection
@@ -207,16 +213,17 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         }
 
         textView?.textColor = theme.text
-        textView?.backgroundColor = theme.background
+        textView.backgroundColor = useThemeBackground ? theme.background : .clear
         textView?.insertionPointColor = theme.insertionPoint
         textView?.selectionBackgroundColor = theme.selection
         textView?.selectedLineHighlightColor = theme.lineHighlight
 
-        rulerView?.backgroundColor = theme.background
+        rulerView?.backgroundColor = useThemeBackground ? theme.background : .clear
         rulerView?.separatorColor = theme.invisibles
         rulerView?.baselineOffset = baselineOffset
 
-        (view as? NSScrollView)?.backgroundColor = theme.background
+        (view as? NSScrollView)?.drawsBackground = useThemeBackground
+        (view as? NSScrollView)?.backgroundColor = useThemeBackground ? theme.background : .clear
         (view as? NSScrollView)?.contentView.contentInsets.bottom = bottomContentInsets
 
         setStandardAttributes()

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -63,21 +63,21 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         language: CodeLanguage,
         font: NSFont,
         theme: EditorTheme,
-        useThemeBackground: Bool,
         tabWidth: Int,
         wrapLines: Bool,
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
-        editorOverscroll: Double
+        editorOverscroll: Double,
+        useThemeBackground: Bool
     ) {
         self.text = text
         self.language = language
         self.font = font
         self.theme = theme
-        self.useThemeBackground = useThemeBackground
         self.tabWidth = tabWidth
         self.wrapLines = wrapLines
         self.cursorPosition = cursorPosition
         self.editorOverscroll = editorOverscroll
+        self.useThemeBackground = useThemeBackground
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -32,6 +32,7 @@ final class STTextViewControllerTests: XCTestCase {
             language: .default,
             font: .monospacedSystemFont(ofSize: 11, weight: .medium),
             theme: theme,
+            useThemeBackground: true,
             tabWidth: 4,
             wrapLines: true,
             editorOverscroll: 0.5

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -32,10 +32,10 @@ final class STTextViewControllerTests: XCTestCase {
             language: .default,
             font: .monospacedSystemFont(ofSize: 11, weight: .medium),
             theme: theme,
-            useThemeBackground: true,
             tabWidth: 4,
             wrapLines: true,
-            editorOverscroll: 0.5
+            editorOverscroll: 0.5,
+            useThemeBackground: true
         )
     }
 


### PR DESCRIPTION
# Description
Adds `useThemeBackground` to `CodeEditTextView` which dictates whether the background of `CodeEditTextView` is clear or uses the given theme background color

# Related
* https://github.com/CodeEditApp/CodeEdit/pull/1004