### PR TITLE
add support for toggling line numbers on and off

### DIFF
--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -22,6 +22,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///   - tabWidth: The tab width
     ///   - lineHeight: The line height multiplier (e.g. `1.2`)
     ///   - wrapLines: Whether lines wrap to the width of the editor
+    ///   - lineNumbers: Whether to display line numbers
     ///   - editorOverscroll: The percentage for overscroll, between 0-1 (default: `0.0`)
     public init(
         _ text: Binding<String>,
@@ -31,6 +32,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         tabWidth: Binding<Int>,
         lineHeight: Binding<Double>,
         wrapLines: Binding<Bool>,
+        lineNumbers: Binding<Bool>,
         editorOverscroll: Binding<Double> = .constant(0.0),
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
         useThemeBackground: Bool = true
@@ -43,6 +45,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self._tabWidth = tabWidth
         self._lineHeight = lineHeight
         self._wrapLines = wrapLines
+        self._lineNumbers = lineNumbers
         self._editorOverscroll = editorOverscroll
         self.cursorPosition = cursorPosition
     }
@@ -54,6 +57,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var tabWidth: Int
     @Binding private var lineHeight: Double
     @Binding private var wrapLines: Bool
+    @Binding private var lineNumbers: Bool
     @Binding private var editorOverscroll: Double
     private var cursorPosition: Published<(Int, Int)>.Publisher?
     private var useThemeBackground: Bool
@@ -68,6 +72,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             theme: theme,
             tabWidth: tabWidth,
             wrapLines: wrapLines,
+            lineNumbers: lineNumbers,
             cursorPosition: cursorPosition,
             editorOverscroll: editorOverscroll,
             useThemeBackground: useThemeBackground
@@ -83,6 +88,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         controller.useThemeBackground = useThemeBackground
         controller.lineHeightMultiple = lineHeight
         controller.editorOverscroll = editorOverscroll
+        controller.lineNumbers = lineNumbers
 
         // Updating the language and theme needlessly can cause highlights to be re-calculated.
         if controller.language.id != language.id {

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -51,6 +51,9 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     /// Whether lines wrap to the width of the editor
     public var wrapLines: Bool
 
+    /// Whether to display line numbers in the editor
+    public var lineNumbers: Bool = true
+
     // MARK: - Highlighting
 
     internal var highlighter: Highlighter?
@@ -65,6 +68,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         theme: EditorTheme,
         tabWidth: Int,
         wrapLines: Bool,
+        lineNumbers: Bool,
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
         editorOverscroll: Double,
         useThemeBackground: Bool
@@ -75,6 +79,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         self.theme = theme
         self.tabWidth = tabWidth
         self.wrapLines = wrapLines
+        self.lineNumbers = lineNumbers
         self.cursorPosition = cursorPosition
         self.editorOverscroll = editorOverscroll
         self.useThemeBackground = useThemeBackground
@@ -102,6 +107,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
         rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
+        rulerView.isHidden = !lineNumbers
+
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true
 
@@ -221,6 +228,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView?.backgroundColor = useThemeBackground ? theme.background : .clear
         rulerView?.separatorColor = theme.invisibles
         rulerView?.baselineOffset = baselineOffset
+        rulerView.isHidden = !lineNumbers
 
         (view as? NSScrollView)?.drawsBackground = useThemeBackground
         (view as? NSScrollView)?.backgroundColor = useThemeBackground ? theme.background : .clear

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -34,6 +34,7 @@ final class STTextViewControllerTests: XCTestCase {
             theme: theme,
             tabWidth: 4,
             wrapLines: true,
+            lineNumbers: true,
             editorOverscroll: 0.5,
             useThemeBackground: true
         )


### PR DESCRIPTION
## Description

Adds support for #115, ✨Option To Hide Line Numbers. Simply shows/hides ruler view. should be easy enough in the future to include affordances for enabling/disabling code folding ribbon, code review, other rulerview utilities once they come into play.

## Demo
![line-numbers](https://user-images.githubusercontent.com/5067237/214153430-e28844c1-5272-46af-8950-eaab6962f987.gif)