### PR TITLE
[chore]: Update CodeEditLanguages to 0.1.9

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "28cf9d50f0bc27fd217bc77b0578d80b9074b252",
-        "version" : "0.1.8"
+        "revision" : "d101d58d615e5ace892a9f006d8b4bb779a9fcb5",
+        "version" : "0.1.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",
-            exact: "0.1.8"
+            exact: "0.1.9"
         ),
         .package(
             url: "https://github.com/lukepistrol/SwiftLintPlugin",


### PR DESCRIPTION
This PR updates `CodeEditLanguages` to `0.1.9` which includes syntax highlighting support for `YAML` files as described in https://github.com/CodeEditApp/CodeEditLanguages/pull/21 and requested in https://github.com/CodeEditApp/CodeEdit/discussions/1021.