### PR TITLE
New Feature: Compute the cursor position 

### DIFF
--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -17,7 +17,6 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///   - text: The text content
     ///   - language: The language for syntax highlighting
     ///   - theme: The theme for syntax highlighting
-    ///   - useThemeBackground: Whether CodeEditTextView uses theme background color or is transparent
     ///   - font: The default font
     ///   - tabWidth: The tab width
     ///   - lineHeight: The line height multiplier (e.g. `1.2`)

--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -36,7 +36,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         lineHeight: Binding<Double>,
         wrapLines: Binding<Bool>,
         editorOverscroll: Binding<Double> = .constant(0.0),
-        cursorPosition: Published<(Int, Int)>.Publisher? = nil,
+        cursorPosition: Binding<(Int, Int)>,
         useThemeBackground: Bool = true,
         highlightProvider: HighlightProviding? = nil,
         contentInsets: NSEdgeInsets? = nil,
@@ -51,7 +51,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self._lineHeight = lineHeight
         self._wrapLines = wrapLines
         self._editorOverscroll = editorOverscroll
-        self.cursorPosition = cursorPosition
+        self._cursorPosition = cursorPosition
         self.highlightProvider = highlightProvider
         self.contentInsets = contentInsets
         self.isEditable = isEditable

--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -66,7 +66,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var lineHeight: Double
     @Binding private var wrapLines: Bool
     @Binding private var editorOverscroll: Double
-    private var cursorPosition: Published<(Int, Int)>.Publisher?
+    @Binding private var cursorPosition: (Int, Int)
     private var useThemeBackground: Bool
     private var highlightProvider: HighlightProviding?
     private var contentInsets: NSEdgeInsets?
@@ -82,7 +82,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             theme: theme,
             tabWidth: tabWidth,
             wrapLines: wrapLines,
-            cursorPosition: cursorPosition,
+            cursorPosition: $cursorPosition,
             editorOverscroll: editorOverscroll,
             useThemeBackground: useThemeBackground,
             highlightProvider: highlightProvider,

--- a/Sources/CodeEditTextView/Controller/STTextViewController+Cursor.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Cursor.swift
@@ -1,0 +1,103 @@
+//
+//  STTextViewController+Cursor.swift
+//  
+//
+//  Created by Elias Wahl on 15.03.23.
+//
+
+import Foundation
+import AppKit
+
+extension STTextViewController {
+    func setCursorPosition(_ position: (Int, Int)) {
+        guard let provider = textView.textLayoutManager.textContentManager else {
+            return
+        }
+
+        var (line, column) = position
+        let string = textView.string
+        if line > 0 {
+            if string.isEmpty {
+                // If the file is blank, automatically place the cursor in the first index.
+                let range = NSRange(string.startIndex..<string.endIndex, in: string)
+                if let newRange = NSTextRange(range, provider: provider) {
+                    _ = self.textView.becomeFirstResponder()
+                    self.textView.setSelectedRange(newRange)
+                    return
+                }
+            }
+
+            string.enumerateSubstrings(in: string.startIndex..<string.endIndex) { _, lineRange, _, done in
+                line -= 1
+                if line < 1 {
+                    // If `column` exceeds the line length, set cursor to the end of the line.
+                    let index = min(lineRange.upperBound, string.index(lineRange.lowerBound, offsetBy: column - 1))
+                    if let newRange = NSTextRange(NSRange(index..<index, in: string), provider: provider) {
+                        self.textView.setSelectedRange(newRange)
+                    }
+                    done = true
+                } else {
+                    done = false
+                }
+            }
+        }
+    }
+
+    func updateCursorPosition() {
+        guard let textLayoutManager = textView.textLayoutManager as NSTextLayoutManager?,
+              let textContentManager = textLayoutManager.textContentManager as NSTextContentManager?,
+              let insertionPointLocation = textLayoutManager.insertionPointLocation,
+              let documentStartLocation = textLayoutManager.documentRange.location as NSTextLocation?,
+              let documentEndLocation = textLayoutManager.documentRange.endLocation as NSTextLocation?
+        else {
+            return
+        }
+
+        let textElements = textContentManager.textElements(
+            for: NSTextRange(location: textLayoutManager.documentRange.location, end: insertionPointLocation)!)
+        var line = textElements.count
+
+        textLayoutManager.enumerateTextSegments(
+                in: NSTextRange(location: insertionPointLocation),
+                type: .standard,
+                options: [.rangeNotRequired, .upstreamAffinity]
+            ) { _, textSegmentFrame, _, _ -> Bool
+                in
+                var col = 1
+                /// If the cursor is at the end of the document:
+                if textLayoutManager.offset(from: insertionPointLocation, to: documentEndLocation) == 0 {
+                    /// If document is empty:
+                    if textLayoutManager.offset(from: documentStartLocation, to: documentEndLocation) == 0 {
+                        self.cursorPosition.wrappedValue = (1, 1)
+                        return false
+                    }
+                    guard let cursorTextFragment = textLayoutManager.textLayoutFragment(for: textSegmentFrame.origin),
+                          let cursorTextLineFragment = cursorTextFragment.textLineFragments.last
+                    else { return false }
+
+                    col = cursorTextLineFragment.characterRange.length + 1
+                    if col == 1 { line += 1 }
+                } else {
+                    guard let cursorTextLineFragment = textLayoutManager.textLineFragment(at: insertionPointLocation)
+                    else { return false }
+
+                    /// +1, because we start with the first character with 1
+                    let tempCol = cursorTextLineFragment.characterIndex(for: textSegmentFrame.origin)
+                    let result = tempCol.addingReportingOverflow(1)
+
+                    if !result.overflow { col = result.partialValue }
+                    /// If cursor is at end of line add 1:
+                    if cursorTextLineFragment.characterRange.length != 1 &&
+                        (cursorTextLineFragment.typographicBounds.width == (textSegmentFrame.maxX + 5.0)) {
+                        col += 1
+                    }
+
+                    /// If cursor is at first character of line, the current line is not being included
+                    if col == 1 { line += 1 }
+                }
+
+                self.cursorPosition.wrappedValue = (line, col)
+                return false
+            }
+        }
+}

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -46,6 +46,9 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     /// The font to use in the `textView`
     public var font: NSFont
 
+    /// The current cursor position e.g. (1, 1)
+    public var cursorPosition: Binding<(Int, Int)>
+
     /// The editorOverscroll to use for the textView over scroll
     public var editorOverscroll: Double
 
@@ -328,102 +331,6 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     override public func keyDown(with event: NSEvent) {
         // TODO: - This should be uncessecary
     }
-
-    // MARK: Cursor Position
-
-    private var cursorPosition: Binding<(Int, Int)>
-
-    private func setCursorPosition(_ position: (Int, Int)) {
-        guard let provider = textView.textLayoutManager.textContentManager else {
-            return
-        }
-
-        var (line, column) = position
-        let string = textView.string
-        if line > 0 {
-            if string.isEmpty {
-                // If the file is blank, automatically place the cursor in the first index.
-                let range = NSRange(string.startIndex..<string.endIndex, in: string)
-                if let newRange = NSTextRange(range, provider: provider) {
-                    _ = self.textView.becomeFirstResponder()
-                    self.textView.setSelectedRange(newRange)
-                    return
-                }
-            }
-
-            string.enumerateSubstrings(in: string.startIndex..<string.endIndex) { _, lineRange, _, done in
-                line -= 1
-                if line < 1 {
-                    // If `column` exceeds the line length, set cursor to the end of the line.
-                    let index = min(lineRange.upperBound, string.index(lineRange.lowerBound, offsetBy: column - 1))
-                    if let newRange = NSTextRange(NSRange(index..<index, in: string), provider: provider) {
-                        self.textView.setSelectedRange(newRange)
-                    }
-                    done = true
-                } else {
-                    done = false
-                }
-            }
-        }
-    }
-
-    private func updateCursorPosition() {
-        guard let textLayoutManager = textView.textLayoutManager as NSTextLayoutManager?,
-              let textContentManager = textLayoutManager.textContentManager as NSTextContentManager?,
-              let insertionPointLocation = textLayoutManager.insertionPointLocation,
-              let documentStartLocation = textLayoutManager.documentRange.location as NSTextLocation?,
-              let documentEndLocation = textLayoutManager.documentRange.endLocation as NSTextLocation?
-        else {
-            return
-        }
-
-        let textElements = textContentManager.textElements(
-            for: NSTextRange(location: textLayoutManager.documentRange.location, end: insertionPointLocation)!)
-        var line = textElements.count
-
-        textLayoutManager.enumerateTextSegments(
-                in: NSTextRange(location: insertionPointLocation),
-                type: .standard,
-                options: [.rangeNotRequired, .upstreamAffinity]
-            ) { _, textSegmentFrame, _, _ -> Bool
-                in
-                var col = 1
-                /// If the cursor is at the end of the document:
-                if textLayoutManager.offset(from: insertionPointLocation, to: documentEndLocation) == 0 {
-                    /// If document is empty:
-                    if textLayoutManager.offset(from: documentStartLocation, to: documentEndLocation) == 0 {
-                        self.cursorPosition.wrappedValue = (1, 1)
-                        return false
-                    }
-                    guard let cursorTextFragment = textLayoutManager.textLayoutFragment(for: textSegmentFrame.origin),
-                          let cursorTextLineFragment = cursorTextFragment.textLineFragments.last
-                    else { return false }
-
-                    col = cursorTextLineFragment.characterRange.length + 1
-                    if col == 1 { line += 1 }
-                } else {
-                    guard let cursorTextLineFragment = textLayoutManager.textLineFragment(at: insertionPointLocation)
-                    else { return false }
-
-                    /// +1, because we start with the first character with 1
-                    let tempCol = cursorTextLineFragment.characterIndex(for: textSegmentFrame.origin)
-                    let result = tempCol.addingReportingOverflow(1)
-
-                    if !result.overflow { col = result.partialValue }
-                    /// If cursor is at end of line add 1:
-                    if cursorTextLineFragment.characterRange.length != 1 &&
-                        (cursorTextLineFragment.typographicBounds.width == (textSegmentFrame.maxX + 5.0)) {
-                        col += 1
-                    }
-
-                    /// If cursor is at first character of line, the current line is not being included
-                    if col == 1 { line += 1 }
-                }
-
-                self.cursorPosition.wrappedValue = (line, col)
-                return false
-            }
-        }
 
     deinit {
         textView = nil

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -188,8 +188,11 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
             (self.view as? NSScrollView)?.contentView.contentInsets.bottom = self.bottomContentInsets
         }
 
-        NotificationCenter.default.addObserver(forName: STTextView.didChangeSelectionNotification,
-                                                       object: nil, queue: .main) { [weak self] _ in
+        NotificationCenter.default.addObserver(
+            forName: STTextView.didChangeSelectionNotification,
+            object: nil, 
+            queue: .main
+        ) { [weak self] _ in
             guard let textLayoutManager = self?.textView.textLayoutManager else { return }
             self?.updateCursorPosition(with: textLayoutManager)
         }

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -403,11 +403,10 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
             }
 
             /// Translate to line and column value
-            textLayoutManager.enumerateTextSegments(in: NSTextRange(location: insertionPointLocation),
-                                                    type: .standard,
-                                                    options:
-                                                        [.rangeNotRequired,
-                                                         .upstreamAffinity]
+            textLayoutManager.enumerateTextSegments(
+                in: NSTextRange(location: insertionPointLocation),
+                type: .standard,
+                options: [.rangeNotRequired, .upstreamAffinity]
             ) { _, textSegmentFrame, _, _ -> Bool
                 in
                 var line = Int(textSegmentFrame.maxY / textSegmentFrame.height)

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -376,8 +376,9 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
             // TODO: Find a more performant approach, that does not scale with line count
             /// Count the line wraps prior to the cursor line
-            textLayoutManager.enumerateTextLayoutFragments(from: textLayoutManager.documentRange.location,
-                                                           options: [.ensuresLayout, .ensuresExtraLineFragment]
+            textLayoutManager.enumerateTextLayoutFragments(
+                from: textLayoutManager.documentRange.location,
+                options: [.ensuresLayout, .ensuresExtraLineFragment]
             ) { textLayoutFragment in
 
                 guard let cursorTextLineFragment = textLayoutManager.textLineFragment(at: insertionPointLocation)

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -190,11 +190,10 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
         NotificationCenter.default.addObserver(
             forName: STTextView.didChangeSelectionNotification,
-            object: nil, 
+            object: nil,
             queue: .main
         ) { [weak self] _ in
-            guard let textLayoutManager = self?.textView.textLayoutManager else { return }
-            self?.updateCursorPosition(with: textLayoutManager)
+            self?.updateCursorPosition()
         }
     }
 
@@ -368,9 +367,12 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         }
     }
 
-    private func updateCursorPosition(with textLayoutManager: NSTextLayoutManager) {
+    private func updateCursorPosition() {
             /// Current cursor location as NSTextLocation
-            guard let insertionPointLocation = textLayoutManager.insertionPointLocation else { return }
+            guard let textLayoutManager = textView.textLayoutManager as NSTextLayoutManager?,
+                  let insertionPointLocation = textLayoutManager.insertionPointLocation else {
+                return
+            }
 
             var lineWrapsCount = 0
 
@@ -409,9 +411,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
                 options: [.rangeNotRequired, .upstreamAffinity]
             ) { _, textSegmentFrame, _, _ -> Bool
                 in
-                var line = Int(textSegmentFrame.maxY / textSegmentFrame.height)
-
-                line -= lineWrapsCount
+                var line = Int(textSegmentFrame.maxY / textSegmentFrame.height) - lineWrapsCount
 
                 guard let cursorTextLineFragment = textLayoutManager.textLineFragment(at: insertionPointLocation)
                 else { return false }
@@ -419,13 +419,10 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
                 /// +1, because we start with the first character with 1
                 var col = cursorTextLineFragment.characterIndex(for: textSegmentFrame.origin) + 1
                 /// If the cursor is at the last character of the line
-                if textSegmentFrame.origin.x + 5.0 == cursorTextLineFragment.typographicBounds.size.width {
-                    col += 1
-                }
+                if textSegmentFrame.origin.x + 5.0 == cursorTextLineFragment.typographicBounds.size.width { col += 1 }
 
                 self.cursorPosition.wrappedValue = (line, col)
-
-               return false
+                return false
             }
         }
 

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -371,7 +371,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         guard let textLayoutManager = textView.textLayoutManager as NSTextLayoutManager?,
               let textContentManager = textLayoutManager.textContentManager as NSTextContentManager?,
               let insertionPointLocation = textLayoutManager.insertionPointLocation,
-              let cursorTextLineFragment = textLayoutManager.textLineFragment(at: insertionPointLocation)
+              let documentStartLocation = textLayoutManager.documentRange.location as NSTextLocation?,
+              let documentEndLocation = textLayoutManager.documentRange.endLocation as NSTextLocation?
         else {
             return
         }
@@ -386,18 +387,38 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
                 options: [.rangeNotRequired, .upstreamAffinity]
             ) { _, textSegmentFrame, _, _ -> Bool
                 in
+                var col = 1
+                /// If the cursor is at the end of the document:
+                if textLayoutManager.offset(from: insertionPointLocation, to: documentEndLocation) == 0 {
+                    /// If document is empty:
+                    if textLayoutManager.offset(from: documentStartLocation, to: documentEndLocation) == 0 {
+                        self.cursorPosition.wrappedValue = (1, 1)
+                        return false
+                    }
+                    guard let cursorTextFragment = textLayoutManager.textLayoutFragment(for: textSegmentFrame.origin),
+                          let cursorTextLineFragment = cursorTextFragment.textLineFragments.last
+                    else { return false }
 
-                /// +1, because we start with the first character with 1
-                var col = cursorTextLineFragment.characterIndex(for: textSegmentFrame.origin) + 1
+                    col = cursorTextLineFragment.characterRange.length + 1
+                    if col == 1 { line += 1 }
+                } else {
+                    guard let cursorTextLineFragment = textLayoutManager.textLineFragment(at: insertionPointLocation)
+                    else { return false }
 
-                /// If cursor is at end of line add 1:
-                if cursorTextLineFragment.characterRange.length != 1 &&
-                    (cursorTextLineFragment.typographicBounds.width == (textSegmentFrame.maxX + 5.0)) {
-                    col += 1
+                    /// +1, because we start with the first character with 1
+                    let tempCol = cursorTextLineFragment.characterIndex(for: textSegmentFrame.origin)
+                    let result = tempCol.addingReportingOverflow(1)
+
+                    if !result.overflow { col = result.partialValue }
+                    /// If cursor is at end of line add 1:
+                    if cursorTextLineFragment.characterRange.length != 1 &&
+                        (cursorTextLineFragment.typographicBounds.width == (textSegmentFrame.maxX + 5.0)) {
+                        col += 1
+                    }
+
+                    /// If cursor is at first character of line, the current line is not being included
+                    if col == 1 { line += 1 }
                 }
-
-                /// If cursor is at first character of line, the current line is not being included
-                if col == 1 { line += 1 }
 
                 self.cursorPosition.wrappedValue = (line, col)
                 return false

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -34,6 +34,7 @@ final class STTextViewControllerTests: XCTestCase {
             theme: theme,
             tabWidth: 4,
             wrapLines: true,
+            cursorPosition: .constant((1, 1)),
             editorOverscroll: 0.5,
             useThemeBackground: true,
             isEditable: true


### PR DESCRIPTION
In essence, the line is calculated by dividing the y-position of the text segment with the cursor by the line height:
```swift 
var line = Int(textSegmentFrame.maxY / textSegmentFrame.height)
```
However, this counts the preceding line wraps as lines too. As a result, I have to count the preceding line wraps with:
```swift
textLayoutManager.enumerateTextLayoutFragments(from: textLayoutManager.documentRange.location,
                                                           options: [.ensuresLayout, .ensuresExtraLineFragment]
            ) { textLayoutFragment in

                guard let cursorTextLineFragment = textLayoutManager.textLineFragment(at: insertionPointLocation)
                else { return false }

                /// Check whether the textLayoutFragment has line wraps
                if textLayoutFragment.textLineFragments.count > 1 {
                    for lineFragment in textLayoutFragment.textLineFragments {
                        lineWrapsCount += 1
                        /// Do not count lineFragments after the lineFragment where the cursor is placed
                        if lineFragment == cursorTextLineFragment { break }
                    }

                    /// The first lineFragment will be counted as an actual line
                        lineWrapsCount -= 1
                }

                if textLayoutFragment.textLineFragments.contains(cursorTextLineFragment) {
                    return false
                }
                return true
            }
```
Unfortunately, this does scale with the line count of the file. So we might want to change that if we can come up with a better alternative in the future. As a first implementation, I think it works.