### PR TITLE
Abstract Highlighter Object

### DIFF
--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -23,6 +23,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///   - lineHeight: The line height multiplier (e.g. `1.2`)
     ///   - wrapLines: Whether lines wrap to the width of the editor
     ///   - editorOverscroll: The percentage for overscroll, between 0-1 (default: `0.0`)
+    ///   - highlightProvider: A class you provide to perform syntax highlighting. Leave this as `nil` to use the
+    ///                        built-in `TreeSitterClient` highlighter.
     public init(
         _ text: Binding<String>,
         language: CodeLanguage,
@@ -33,7 +35,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         wrapLines: Binding<Bool>,
         editorOverscroll: Binding<Double> = .constant(0.0),
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
-        useThemeBackground: Bool = true
+        useThemeBackground: Bool = true,
+        highlightProvider: HighlightProviding? = nil
     ) {
         self._text = text
         self.language = language
@@ -45,6 +48,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self._wrapLines = wrapLines
         self._editorOverscroll = editorOverscroll
         self.cursorPosition = cursorPosition
+        self.highlightProvider = highlightProvider
     }
 
     @Binding private var text: String
@@ -57,6 +61,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var editorOverscroll: Double
     private var cursorPosition: Published<(Int, Int)>.Publisher?
     private var useThemeBackground: Bool
+    private var highlightProvider: HighlightProviding?
 
     public typealias NSViewControllerType = STTextViewController
 
@@ -70,7 +75,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             wrapLines: wrapLines,
             cursorPosition: cursorPosition,
             editorOverscroll: editorOverscroll,
-            useThemeBackground: useThemeBackground
+            useThemeBackground: useThemeBackground,
+            highlightProvider: highlightProvider
         )
         controller.lineHeightMultiple = lineHeight
         return controller

--- a/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+VisibleRange.swift
+++ b/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+VisibleRange.swift
@@ -31,6 +31,9 @@ extension STTextView {
               let end = textLayoutManager.textLayoutFragment(for: maxPoint)?.rangeInElement.endLocation else {
             return textLayoutManager.documentRange.nsRange(using: textContentStorage)
         }
+        guard start.compare(end) != .orderedDescending else {
+            return NSTextRange(location: end, end: start)?.nsRange(using: textContentStorage)
+        }
 
         // Calculate a range and return it as an `NSRange`
         return NSTextRange(location: start, end: end)?.nsRange(using: textContentStorage)

--- a/Sources/CodeEditTextView/Extensions/String+encoding.swift
+++ b/Sources/CodeEditTextView/Extensions/String+encoding.swift
@@ -1,0 +1,17 @@
+//
+//  String+encoding.swift
+//  
+//
+//  Created by Khan Winter on 1/19/23.
+//
+
+import Foundation
+
+extension String {
+    static var nativeUTF16Encoding: String.Encoding {
+        let dataA = "abc".data(using: .utf16LittleEndian)
+        let dataB = "abc".data(using: .utf16)?.suffix(from: 2)
+
+        return dataA == dataB ? .utf16LittleEndian : .utf16BigEndian
+    }
+}

--- a/Sources/CodeEditTextView/Highlighting/HighlightProviding.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlightProviding.swift
@@ -1,0 +1,47 @@
+//
+//  HighlightProviding.swift
+//  
+//
+//  Created by Khan Winter on 1/18/23.
+//
+
+import Foundation
+import CodeEditLanguages
+import STTextView
+import AppKit
+
+/// The protocol a class must conform to to be used for highlighting.
+public protocol HighlightProviding {
+    /// A unique identifier for the highlighter object.
+    /// Example: `"CodeEdit.TreeSitterHighlighter"`
+    /// - Note: This does not need to be *globally* unique, merely unique across all the highlighters used.
+    var identifier: String { get }
+
+    /// Updates the highlighter's code language.
+    /// - Parameters:
+    ///   - codeLanguage: The langugage that should be used by the highlighter.
+    func setLanguage(codeLanguage: CodeLanguage)
+
+    /// Notifies the highlighter of an edit and in exchange gets a set of indices that need to be re-highlighted.
+    /// The returned `IndexSet` should include all indexes that need to be highlighted, including any inserted text.
+    /// - Parameters:
+    ///   - textView:The text view to use.
+    ///   - range: The range of the edit.
+    ///   - delta: The length of the edit, can be negative for deletions.
+    ///   - completion: The function to call with an `IndexSet` containing all Indices to invalidate.
+    func applyEdit(textView: HighlighterTextView,
+                   range: NSRange,
+                   delta: Int,
+                   completion: @escaping ((IndexSet) -> Void))
+
+    /// Queries the highlight provider for any ranges to apply highlights to. The highlight provider should return an
+    /// array containing all ranges to highlight, and the capture type for the range. Any ranges or indexes
+    /// excluded from the returned array will be treated as plain text and highlighted as such.
+    /// - Parameters:
+    ///   - textView: The text view to use.
+    ///   - range: The range to operate on.
+    ///   - completion: Function to call with all ranges to highlight
+    func queryColorsFor(textView: HighlighterTextView,
+                        range: NSRange,
+                        completion: @escaping (([HighlightRange]) -> Void))
+}

--- a/Sources/CodeEditTextView/Highlighting/HighlightProviding.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlightProviding.swift
@@ -41,7 +41,7 @@ public protocol HighlightProviding {
     ///   - textView: The text view to use.
     ///   - range: The range to operate on.
     ///   - completion: Function to call with all ranges to highlight
-    func queryColorsFor(textView: HighlighterTextView,
-                        range: NSRange,
-                        completion: @escaping (([HighlightRange]) -> Void))
+    func queryHighlightsFor(textView: HighlighterTextView,
+                            range: NSRange,
+                            completion: @escaping (([HighlightRange]) -> Void))
 }

--- a/Sources/CodeEditTextView/Highlighting/HighlightRange.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlightRange.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// This class represents a range to highlight, as well as the capture name for syntax coloring.
-class HighlightRange {
+public class HighlightRange {
     init(range: NSRange, capture: CaptureName?) {
         self.range = range
         self.capture = capture

--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -165,8 +165,8 @@ private extension Highlighter {
     func highlight(range rangeToHighlight: NSRange) {
         pendingSet.insert(integersIn: rangeToHighlight)
 
-        highlightProvider?.queryColorsFor(textView: self.textView,
-                                          range: rangeToHighlight) { [weak self] highlightRanges in
+        highlightProvider?.queryHighlightsFor(textView: self.textView,
+                                              range: rangeToHighlight) { [weak self] highlightRanges in
             guard let attributeProvider = self?.attributeProvider,
                   let textView = self?.textView else { return }
 

--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -11,11 +11,6 @@ import STTextView
 import SwiftTreeSitter
 import CodeEditLanguages
 
-/// Classes conforming to this protocol can provide attributes for text given a capture type.
-public protocol ThemeAttributesProviding {
-    func attributesFor(_ capture: CaptureName?) -> [NSAttributedString.Key: Any]
-}
-
 /// The `Highlighter` class handles efficiently highlighting the `STTextView` it's provided with.
 /// It will listen for text and visibility changes, and highlight syntax as needed.
 ///
@@ -49,13 +44,21 @@ class Highlighter: NSObject {
 
     /// The text view to highlight
     private var textView: STTextView
+
+    /// The editor theme
     private var theme: EditorTheme
+
+    /// The object providing attributes for captures.
     private var attributeProvider: ThemeAttributesProviding!
 
-    // MARK: - TreeSitter Client
+    /// The current language of the editor.
+    private var language: CodeLanguage
 
     /// Calculates invalidated ranges given an edit.
-    private var treeSitterClient: TreeSitterClient?
+    private var highlightProvider: HighlightProviding?
+
+    /// The length to chunk ranges into when passing to the highlighter.
+    fileprivate let rangeChunkLimit = 256
 
     // MARK: - Init
 
@@ -65,17 +68,19 @@ class Highlighter: NSObject {
     ///   - treeSitterClient: The tree-sitter client to handle tree updates and highlight queries.
     ///   - theme: The theme to use for highlights.
     init(textView: STTextView,
-         treeSitterClient: TreeSitterClient?,
+         highlightProvider: HighlightProviding?,
          theme: EditorTheme,
-         attributeProvider: ThemeAttributesProviding) {
+         attributeProvider: ThemeAttributesProviding,
+         language: CodeLanguage) {
         self.textView = textView
-        self.treeSitterClient = treeSitterClient
+        self.highlightProvider = highlightProvider
         self.theme = theme
         self.attributeProvider = attributeProvider
+        self.language = language
 
         super.init()
 
-        treeSitterClient?.setText(text: textView.string)
+        highlightProvider?.setLanguage(codeLanguage: language)
 
         guard textView.textContentStorage.textStorage != nil else {
             assertionFailure("Text view does not have a textStorage")
@@ -100,17 +105,22 @@ class Highlighter: NSObject {
     // MARK: - Public
 
     /// Invalidates all text in the textview. Useful for updating themes.
-    func invalidate() {
-        if !(treeSitterClient?.hasSetText ?? true) {
-            treeSitterClient?.setText(text: textView.string)
-        }
+    public func invalidate() {
         invalidate(range: NSRange(entireTextRange))
     }
 
     /// Sets the language and causes a re-highlight of the entire text.
     /// - Parameter language: The language to update to.
-    func setLanguage(language: CodeLanguage) throws {
-        try treeSitterClient?.setLanguage(codeLanguage: language, text: textView.string)
+    public func setLanguage(language: CodeLanguage) {
+        highlightProvider?.setLanguage(codeLanguage: language)
+        invalidate()
+    }
+
+    /// Sets the highlight provider. Will cause a re-highlight of the entire text.
+    /// - Parameter provider: The provider to use for future syntax highlights.
+    public func setHighlightProvider(_ provider: HighlightProviding) {
+        self.highlightProvider = provider
+        highlightProvider?.setLanguage(codeLanguage: language)
         invalidate()
     }
 
@@ -155,7 +165,8 @@ private extension Highlighter {
     func highlight(range rangeToHighlight: NSRange) {
         pendingSet.insert(integersIn: rangeToHighlight)
 
-        treeSitterClient?.queryColorsFor(range: rangeToHighlight) { [weak self] highlightRanges in
+        highlightProvider?.queryColorsFor(textView: self.textView,
+                                          range: rangeToHighlight) { [weak self] highlightRanges in
             guard let attributeProvider = self?.attributeProvider,
                   let textView = self?.textView else { return }
 
@@ -222,11 +233,12 @@ private extension Highlighter {
             .intersection(visibleSet) // Only visible indexes
             .subtracting(pendingSet) // Don't include pending indexes
 
-        guard let range = set.rangeView.map({ NSRange($0) }).first else {
+        guard let range = set.rangeView.first else {
             return nil
         }
 
-        return range
+        // Chunk the ranges in sets of rangeChunkLimit characters.
+        return NSRange(location: range.lowerBound, length: min(rangeChunkLimit, range.upperBound))
     }
 
 }
@@ -256,7 +268,6 @@ extension Highlighter: NSTextStorageDelegate {
                      didProcessEditing editedMask: NSTextStorageEditActions,
                      range editedRange: NSRange,
                      changeInLength delta: Int) {
-
         // This method is called whenever attributes are updated, so to avoid re-highlighting the entire document
         // each time an attribute is applied, we check to make sure this is in response to an edit.
         guard editedMask.contains(.editedCharacters) else {
@@ -265,12 +276,9 @@ extension Highlighter: NSTextStorageDelegate {
 
         let range = NSRange(location: editedRange.location, length: editedRange.length - delta)
 
-        guard let edit = InputEdit(range: range, delta: delta, oldEndPoint: .zero) else {
-            return
-        }
-
-        treeSitterClient?.applyEdit(edit,
-                                   text: textStorage.string) { [weak self] invalidatedIndexSet in
+        highlightProvider?.applyEdit(textView: self.textView,
+                                     range: range,
+                                     delta: delta) { [weak self] invalidatedIndexSet in
             let indexSet = invalidatedIndexSet
                 .union(IndexSet(integersIn: editedRange))
                 // Only invalidate indices that aren't visible.

--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -238,7 +238,8 @@ private extension Highlighter {
         }
 
         // Chunk the ranges in sets of rangeChunkLimit characters.
-        return NSRange(location: range.lowerBound, length: min(rangeChunkLimit, range.upperBound))
+        return NSRange(location: range.lowerBound,
+                       length: min(rangeChunkLimit, range.upperBound - range.lowerBound))
     }
 
 }

--- a/Sources/CodeEditTextView/Highlighting/HighlighterTextView.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlighterTextView.swift
@@ -20,7 +20,8 @@ public protocol HighlighterTextView {
 /// A default implementation for `STTextView` to be passed to `HighlightProviding` objects.
 extension STTextView: HighlighterTextView {
     public var documentRange: NSRange {
-        return textLayoutManager.documentRange.nsRange(using: textContentStorage) ?? NSRange()
+        return NSRange(location: 0,
+                       length: textContentStorage.textStorage?.length ?? 0)
     }
 
     public func stringForRange(_ nsRange: NSRange) -> String? {

--- a/Sources/CodeEditTextView/Highlighting/HighlighterTextView.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlighterTextView.swift
@@ -1,0 +1,29 @@
+//
+//  HighlighterTextView.swift
+//  
+//
+//  Created by Khan Winter on 1/26/23.
+//
+
+import Foundation
+import AppKit
+import STTextView
+
+/// The object `HighlightProviding` objects are given when asked for highlights.
+public protocol HighlighterTextView {
+    /// The entire range of the document.
+    var documentRange: NSRange { get }
+    /// A substring for the requested range.
+    func stringForRange(_ nsRange: NSRange) -> String?
+}
+
+/// A default implementation for `STTextView` to be passed to `HighlightProviding` objects.
+extension STTextView: HighlighterTextView {
+    public var documentRange: NSRange {
+        return textLayoutManager.documentRange.nsRange(using: textContentStorage) ?? NSRange()
+    }
+
+    public func stringForRange(_ nsRange: NSRange) -> String? {
+        return textContentStorage.textStorage?.mutableString.substring(with: nsRange)
+    }
+}

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -25,7 +25,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     /// The associated `CodeLanguage`
     public var language: CodeLanguage { didSet {
         // TODO: Decide how to handle errors thrown here
-        try? highlighter?.setLanguage(language: language)
+        highlighter?.setLanguage(language: language)
     }}
 
     /// The associated `Theme` used for highlighting.
@@ -51,10 +51,14 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     /// Whether lines wrap to the width of the editor
     public var wrapLines: Bool
 
-    // MARK: - Highlighting
-
+    /// The `Highlighter` object.
     internal var highlighter: Highlighter?
+
+    /// Internal variable for tracking whether or not the textView has the correct standard attributes.
     private var hasSetStandardAttributes: Bool = false
+
+    /// The provided highlight provider.
+    private var highlightProvider: HighlightProviding?
 
     // MARK: Init
 
@@ -67,7 +71,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         wrapLines: Bool,
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
         editorOverscroll: Double,
-        useThemeBackground: Bool
+        useThemeBackground: Bool,
+        highlightProvider: HighlightProviding? = nil
     ) {
         self.text = text
         self.language = language
@@ -78,6 +83,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         self.cursorPosition = cursorPosition
         self.editorOverscroll = editorOverscroll
         self.useThemeBackground = useThemeBackground
+        self.highlightProvider = highlightProvider
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -143,23 +149,12 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
             return event
         }
 
-        setUpHighlighting()
+        setUpHighlighter()
+        setHighlightProvider(self.highlightProvider)
 
         self.cursorPositionCancellable = self.cursorPosition?.sink(receiveValue: { value in
             self.setCursorPosition(value)
         })
-    }
-
-    internal func setUpHighlighting() {
-        let textProvider: ResolvingQueryCursor.TextProvider = { [weak self] range, _ -> String? in
-            return self?.textView.textContentStorage.textStorage?.attributedSubstring(from: range).string
-        }
-
-        let treeSitterClient = try? TreeSitterClient(codeLanguage: language, textProvider: textProvider)
-        self.highlighter = Highlighter(textView: textView,
-                                       treeSitterClient: treeSitterClient,
-                                       theme: theme,
-                                       attributeProvider: self)
     }
 
     public override func viewDidLoad() {
@@ -257,6 +252,37 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     /// Calculated baseline offset depending on `lineHeight`.
     internal var baselineOffset: Double {
         ((self.lineHeight) - font.lineHeight) / 2
+    }
+
+    // MARK: - Highlighting
+
+    /// Configures the `Highlighter` object
+    private func setUpHighlighter() {
+        self.highlighter = Highlighter(textView: textView,
+                                       highlightProvider: highlightProvider,
+                                       theme: theme,
+                                       attributeProvider: self,
+                                       language: language)
+    }
+
+    /// Sets the highlight provider and re-highlights all text. This method should be used sparingly.
+    public func setHighlightProvider(_ highlightProvider: HighlightProviding? = nil) {
+        var provider: HighlightProviding?
+
+        if let highlightProvider = highlightProvider {
+            provider = highlightProvider
+        } else {
+            let textProvider: ResolvingQueryCursor.TextProvider = { [weak self] range, _ -> String? in
+                return self?.textView.textContentStorage.textStorage?.mutableString.substring(with: range)
+            }
+
+            provider = try? TreeSitterClient(codeLanguage: language, textProvider: textProvider)
+        }
+
+        if let provider = provider {
+            self.highlightProvider = provider
+            highlighter?.setHighlightProvider(provider)
+        }
     }
 
     // MARK: Key Presses

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -149,7 +149,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
             return event
         }
 
-        setUpHighlighting()
+        setUpHighlighter()
         setHighlightProvider(self.highlightProvider)
         setUpTextFormation()
 

--- a/Sources/CodeEditTextView/Theme/ThemeAttributesProviding.swift
+++ b/Sources/CodeEditTextView/Theme/ThemeAttributesProviding.swift
@@ -1,0 +1,13 @@
+//
+//  ThemeAttributesProviding.swift
+//  
+//
+//  Created by Khan Winter on 1/18/23.
+//
+
+import Foundation
+
+/// Classes conforming to this protocol can provide attributes for text given a capture type.
+public protocol ThemeAttributesProviding {
+    func attributesFor(_ capture: CaptureName?) -> [NSAttributedString.Key: Any]
+}

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
@@ -178,7 +178,7 @@ extension TreeSitterClient {
     /// processed edit.
     /// - Parameters:
     ///   - edit: The edit to apply.
-    ///   - readBlock:  The block to use to read text.
+    ///   - readBlock: The block to use to read text.
     /// - Returns: (The old state, the new state).
     private func calculateNewState(edit: InputEdit,
                                    readBlock: @escaping Parser.ReadBlock) -> (Tree?, Tree?) {
@@ -186,7 +186,7 @@ extension TreeSitterClient {
             return (nil, nil)
         }
         self.semaphore.wait()
-        
+
         // Apply the edit to the old tree
         oldTree.edit(edit)
 

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
@@ -106,9 +106,9 @@ final class TreeSitterClient: HighlightProviding {
         completion(rangeSet)
     }
 
-    func queryColorsFor(textView: HighlighterTextView,
-                        range: NSRange,
-                        completion: @escaping (([HighlightRange]) -> Void)) {
+    func queryHighlightsFor(textView: HighlighterTextView,
+                            range: NSRange,
+                            completion: @escaping (([HighlightRange]) -> Void)) {
         // Make sure we dont accidentally change the tree while we copy it.
         self.semaphore.wait()
         guard let tree = self.tree?.copy() else {


### PR DESCRIPTION
# Description

This PR adds an abstraction layer to the `Highlighter` object. Currently, our `TreeSitterClient` is tightly integrated with our highlighter, which works great. However, it limits our ability to easily use multiple highlighter providers (eg: tree-sitter, and LSP). To fix this, I've added a `HighlightProvider` protocol that CETV can interrogate for syntax information to use for highlighting.

This is the first step towards using more than one highlighter. A future PR will need to add the ability for our highlighter to manage highlights from two or more providers. Once that is done #40 can be started.

# Related Issues

- #40 

# Detailed Implementation

For the abstraction layer, I've added a `HighlightProviding` protocol, and an accompanying `HighlighterTextView` protocol. Classes conforming to the `HighlightProviding` protocol have a hook to change the language, update text, and return highlights for a text range. 

The `HighlighterTextView` protocol exists so that highlight providers aren't given complete access to the text view. This is done to encourage providers to do as little string copying as possible by providing methods for getting substrings and the document range in the text view.

Because of these changes, the `TreeSitterClient` class was heavily modified. It was mostly changed to use a `ReadBlock` while applying changes, and no longer needs to have the text "set" before doing any work. I benchmarked editing and highlighting before and after making these changes, and saw a negligible change in performance between them.


