### PR TITLE
Make STTextView first responder when opening an empty file (CodeEdit #696)

### DIFF
--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -321,6 +321,16 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         var (line, column) = position
         let string = textView.string
         if line > 0 {
+            if string.isEmpty {
+                // If the file is blank, automatically place the cursor in the first index.
+                let range = NSRange(string.startIndex..<string.endIndex, in: string)
+                if let newRange = NSTextRange(range, provider: provider) {
+                    _ = self.textView.becomeFirstResponder()
+                    self.textView.setSelectedRange(newRange)
+                    return
+                }
+            }
+
             string.enumerateSubstrings(in: string.startIndex..<string.endIndex) { _, lineRange, _, done in
                 line -= 1
                 if line < 1 {


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

* In `STTextViewController.swift`, the `setCursorPosition` function was changed so that, if the currently open file is empty, the cursor is automatically set to the first position and active. This behavior is similar to other text editors e.g. VSCode.

A related PR is opened in CodeEdit, which works in tandem with this one, so that newly-created files automatically open in a new editor tab.

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* [#696](https://github.com/CodeEditApp/CodeEdit/issues/696) from CodeEdit.
* PR [#1057](https://github.com/CodeEditApp/CodeEdit/pull/1057) from CodeEdit.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots