### PR TITLE
Make cursor appear when clicking after the last line of a file (#56)

### DIFF
--- a/Sources/CodeEditTextView/CEScrollView.swift
+++ b/Sources/CodeEditTextView/CEScrollView.swift
@@ -16,7 +16,7 @@ class CEScrollView: NSScrollView {
             !textView.visibleRect.contains(event.locationInWindow) {
             // If the `scrollView` was clicked, but the click did not happen within the `textView`,
             // set cursor to the last index of the `textView`.
-            
+
             let endLocation = textView.textLayoutManager.documentRange.endLocation
             let range = NSTextRange(location: endLocation)
             _ = textView.becomeFirstResponder()

--- a/Sources/CodeEditTextView/CEScrollView.swift
+++ b/Sources/CodeEditTextView/CEScrollView.swift
@@ -1,0 +1,28 @@
+//
+//  CEScrollView.swift
+//  
+//
+//  Created by Renan Greca on 18/02/23.
+//
+
+import AppKit
+import STTextView
+
+class CEScrollView: NSScrollView {
+
+    override func mouseDown(with event: NSEvent) {
+
+        if let textView = self.documentView as? STTextView,
+            !textView.visibleRect.contains(event.locationInWindow) {
+            // If the `scrollView` was clicked, but the click did not happen within the `textView`,
+            // set cursor to the last index of the `textView`.
+            
+            let endLocation = textView.textLayoutManager.documentRange.endLocation
+            let range = NSTextRange(location: endLocation)
+            _ = textView.becomeFirstResponder()
+            textView.setSelectedRange(range)
+        }
+
+        super.mouseDown(with: event)
+    }
+}

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -342,30 +342,3 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         highlighter = nil
     }
 }
-
-class CEScrollView: NSScrollView {
-
-    override func mouseDown(with event: NSEvent) {
-
-        if let textView = self.documentView as? STTextView,
-            !textView.visibleRect.contains(event.locationInWindow) {
-            // If the `scrollView` was clicked, but the click did not happen within the `textView`,
-            // set cursor to the last index of the `textView`.
-
-            guard let provider = textView.textLayoutManager.textContentManager else {
-                return
-            }
-
-            let string = textView.string
-
-            let range = NSRange(string.endIndex..<string.endIndex, in: string)
-            if let newRange = NSTextRange(range, provider: provider) {
-                _ = textView.becomeFirstResponder()
-                textView.setSelectedRange(newRange)
-                return
-            }
-        }
-
-        super.mouseDown(with: event)
-    }
-}

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -107,7 +107,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     public override func loadView() {
         textView = STTextView()
 
-        let scrollView = NSScrollView()
+        let scrollView = CEScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true
         scrollView.documentView = textView
@@ -340,5 +340,32 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     deinit {
         textView = nil
         highlighter = nil
+    }
+}
+
+class CEScrollView: NSScrollView {
+
+    override func mouseDown(with event: NSEvent) {
+
+        if let textView = self.documentView as? STTextView,
+            !textView.visibleRect.contains(event.locationInWindow) {
+            // If the `scrollView` was clicked, but the click did not happen within the `textView`,
+            // set cursor to the last index of the `textView`.
+
+            guard let provider = textView.textLayoutManager.textContentManager else {
+                return
+            }
+
+            let string = textView.string
+
+            let range = NSRange(string.endIndex..<string.endIndex, in: string)
+            if let newRange = NSTextRange(range, provider: provider) {
+                _ = textView.becomeFirstResponder()
+                textView.setSelectedRange(newRange)
+                return
+            }
+        }
+
+        super.mouseDown(with: event)
     }
 }


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

* In `STTextViewController.swift`, I created a subclass of `NSScrollView` to implement a custom `mouseDown(with event:)` function. The function makes it so, if a click is detected within the ScrollView but out of the contained STTextView, the editor cursor is placed on the last index of the text.

I created the subclass at the end of `STTextViewController.swift`, but it should probably go to its own file; upon review I would like suggestions of where to place this file, as none of the current directories seem appropriate for it.

Additionally, the name of the class is `CEScrollView` (`CE` for CodeEdit); I am not sure if there is a different naming convention customized subclasses. 

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #56 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots