### PR TITLE
Add Injected Language Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",
-            exact: "0.1.12"
+            from: "0.1.13"
         ),
         .package(
             url: "https://github.com/lukepistrol/SwiftLintPlugin",

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",
-            exact: "0.1.11"
+            from: "0.1.10"
         ),
         .package(
             url: "https://github.com/lukepistrol/SwiftLintPlugin",

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",
-            from: "0.1.10"
+            exact: "0.1.12"
         ),
         .package(
             url: "https://github.com/lukepistrol/SwiftLintPlugin",

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -316,7 +316,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
                 return self?.textView.textContentStorage.textStorage?.mutableString.substring(with: range)
             }
 
-            provider = try? TreeSitterClient(codeLanguage: language, textProvider: textProvider)
+            provider = TreeSitterClient(codeLanguage: language, textProvider: textProvider)
         }
 
         if let provider = provider {

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+Comparable.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+Comparable.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  NSRange+Comparable.swift
 //  
 //
 //  Created by Khan Winter on 3/15/23.

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+Comparable.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+Comparable.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Khan Winter on 3/15/23.
+//
+
+import Foundation
+
+extension NSRange: Comparable {
+    public static func == (lhs: NSRange, rhs: NSRange) -> Bool {
+        return lhs.location == rhs.location && lhs.length == rhs.length
+    }
+
+    public static func < (lhs: NSRange, rhs: NSRange) -> Bool {
+        return lhs.location < rhs.location
+    }
+}

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+InputEdit.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+InputEdit.swift
@@ -29,37 +29,3 @@ extension InputEdit {
                   newEndPoint: newEndPoint)
     }
 }
-
-extension NSRange {
-    // swiftlint:disable line_length
-
-    /// Modifies the range to account for an edit.
-    /// Largely based on:
-    /// [tree-sitter](https://github.com/tree-sitter/tree-sitter/blob/ddeaa0c7f534268b35b4f6cb39b52df082754413/lib/src/subtree.c#L691-L720)
-    mutating func applyInputEdit(_ edit: InputEdit) {
-        // swiftlint:enable line_length
-
-        let endIndex = NSMaxRange(self)
-        let isPureInsertion = edit.oldEndByte == edit.startByte
-
-        // Edit is after the range
-        if (edit.startByte/2) > endIndex {
-            return
-        } else if edit.oldEndByte/2 < location {
-            // If the edit is entirely before this range
-            self.location += (Int(edit.newEndByte) - Int(edit.oldEndByte))/2
-        } else if edit.startByte/2 < location {
-            // If the edit starts in the space before this range and extends into this range
-            length -= Int(edit.oldEndByte)/2 - location
-            location = Int(edit.newEndByte)/2
-        } else if edit.startByte/2 == location && isPureInsertion {
-            // If the edit is *only* an insertion right at the beginning of the range
-            location = Int(edit.newEndByte)/2
-        } else {
-            // Otherwise, the edit is entirely within this range
-            if edit.startByte/2 < endIndex || (edit.startByte/2 == endIndex && isPureInsertion) {
-                length = (Int(edit.newEndByte)/2 - location) + (length - (Int(edit.oldEndByte)/2 - location))
-            }
-        }
-    }
-}

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+InputEdit.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+InputEdit.swift
@@ -29,3 +29,35 @@ extension InputEdit {
                   newEndPoint: newEndPoint)
     }
 }
+
+extension NSRange {
+    // swiftlint:disable line_length
+    /// Modifies the range to account for an edit.
+    /// Largely based on code from
+    /// [tree-sitter](https://github.com/tree-sitter/tree-sitter/blob/ddeaa0c7f534268b35b4f6cb39b52df082754413/lib/src/subtree.c#L691-L720)
+    mutating func applyInputEdit(_ edit: InputEdit) {
+        // swiftlint:enable line_length
+        let endIndex = NSMaxRange(self)
+        let isPureInsertion = edit.oldEndByte == edit.startByte
+
+        // Edit is after the range
+        if (edit.startByte/2) > endIndex {
+            return
+        } else if edit.oldEndByte/2 < location {
+            // If the edit is entirely before this range
+            self.location += (Int(edit.newEndByte) - Int(edit.oldEndByte))/2
+        } else if edit.startByte/2 < location {
+            // If the edit starts in the space before this range and extends into this range
+            length -= Int(edit.oldEndByte)/2 - location
+            location = Int(edit.newEndByte)/2
+        } else if edit.startByte/2 == location && isPureInsertion {
+            // If the edit is *only* an insertion right at the beginning of the range
+            location = Int(edit.newEndByte)/2
+        } else {
+            // Otherwise, the edit is entirely within this range
+            if edit.startByte/2 < endIndex || (edit.startByte/2 == endIndex && isPureInsertion) {
+                length = (Int(edit.newEndByte)/2 - location) + (length - (Int(edit.oldEndByte)/2 - location))
+            }
+        }
+    }
+}

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+InputEdit.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+InputEdit.swift
@@ -29,3 +29,37 @@ extension InputEdit {
                   newEndPoint: newEndPoint)
     }
 }
+
+extension NSRange {
+    // swiftlint:disable line_length
+
+    /// Modifies the range to account for an edit.
+    /// Largely based on:
+    /// [tree-sitter](https://github.com/tree-sitter/tree-sitter/blob/ddeaa0c7f534268b35b4f6cb39b52df082754413/lib/src/subtree.c#L691-L720)
+    mutating func applyInputEdit(_ edit: InputEdit) {
+        // swiftlint:enable line_length
+
+        let endIndex = NSMaxRange(self)
+        let isPureInsertion = edit.oldEndByte == edit.startByte
+
+        // Edit is after the range
+        if (edit.startByte/2) > endIndex {
+            return
+        } else if edit.oldEndByte/2 < location {
+            // If the edit is entirely before this range
+            self.location += (Int(edit.newEndByte) - Int(edit.oldEndByte))/2
+        } else if edit.startByte/2 < location {
+            // If the edit starts in the space before this range and extends into this range
+            length -= Int(edit.oldEndByte)/2 - location
+            location = Int(edit.newEndByte)/2
+        } else if edit.startByte/2 == location && isPureInsertion {
+            // If the edit is *only* an insertion right at the beginning of the range
+            location = Int(edit.newEndByte)/2
+        } else {
+            // Otherwise, the edit is entirely within this range
+            if edit.startByte/2 < endIndex || (edit.startByte/2 == endIndex && isPureInsertion) {
+                length = (Int(edit.newEndByte)/2 - location) + (length - (Int(edit.oldEndByte)/2 - location))
+            }
+        }
+    }
+}

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+TSRange.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+TSRange.swift
@@ -10,7 +10,9 @@ import SwiftTreeSitter
 
 extension NSRange {
     var tsRange: TSRange {
-        return TSRange(points: .zero..<(.zero),
-                       bytes: (UInt32(self.location) * 2)..<(UInt32(self.location + self.length) * 2))
+        return TSRange(
+            points: .zero..<(.zero),
+            bytes: (UInt32(self.location) * 2)..<(UInt32(self.location + self.length) * 2)
+        )
     }
 }

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+TSRange.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+TSRange.swift
@@ -1,0 +1,15 @@
+//
+//  NSRange+TSRange.swift
+//  
+//
+//  Created by Khan Winter on 2/26/23.
+//
+
+import Foundation
+import SwiftTreeSitter
+
+extension NSRange {
+    var tsRange: TSRange {
+        return TSRange(points: .zero..<(.zero), bytes: (UInt32(self.lowerBound) * 2)..<(UInt32(self.upperBound) * 2))
+    }
+}

--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+TSRange.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+TSRange.swift
@@ -10,6 +10,7 @@ import SwiftTreeSitter
 
 extension NSRange {
     var tsRange: TSRange {
-        return TSRange(points: .zero..<(.zero), bytes: (UInt32(self.lowerBound) * 2)..<(UInt32(self.upperBound) * 2))
+        return TSRange(points: .zero..<(.zero),
+                       bytes: (UInt32(self.location) * 2)..<(UInt32(self.location + self.length) * 2))
     }
 }

--- a/Sources/CodeEditTextView/Extensions/Tree+prettyPrint.swift
+++ b/Sources/CodeEditTextView/Extensions/Tree+prettyPrint.swift
@@ -1,0 +1,71 @@
+//
+//  Tree+prettyPrint.swift
+//  
+//
+//  Created by Khan Winter on 3/16/23.
+//
+
+import SwiftTreeSitter
+
+#if DEBUG
+extension Tree {
+    func prettyPrint() {
+        guard let cursor = self.rootNode?.treeCursor else {
+            print("NO ROOT NODE")
+            return
+        }
+        guard cursor.currentNode != nil else {
+            print("NO CURRENT NODE")
+            return
+        }
+
+        func p(_ cursor: TreeCursor, depth: Int) {
+            guard let node = cursor.currentNode else {
+                return
+            }
+
+            let visible = node.isNamed
+
+            if visible {
+                print(String(repeating: " ", count: depth * 2), terminator: "")
+                if let fieldName = cursor.currentFieldName {
+                    print(fieldName, ": ", separator: "", terminator: "")
+                }
+                print("(", node.nodeType ?? "NONE", " ", node.range, " ", separator: "", terminator: "")
+            }
+
+            if cursor.goToFirstChild() {
+                while true {
+                    if cursor.currentNode != nil && cursor.currentNode!.isNamed {
+                        print("")
+                    }
+
+                    p(cursor, depth: depth + 1)
+
+                    if !cursor.gotoNextSibling() {
+                        break
+                    }
+                }
+
+                if !cursor.gotoParent() {
+                    fatalError("Could not go to parent, this tree may be invalid.")
+                }
+            }
+
+            if visible {
+                print(")", terminator: "")
+            }
+        }
+
+        if cursor.currentNode?.childCount == 0 {
+            if !cursor.currentNode!.isNamed {
+                print("{\(cursor.currentNode!.nodeType ?? "NONE")}")
+            } else {
+                print("\"\(cursor.currentNode!.nodeType ?? "NONE")\"")
+            }
+        } else {
+            p(cursor, depth: 1)
+        }
+    }
+}
+#endif

--- a/Sources/CodeEditTextView/Filters/STTextViewController+TextFormation.swift
+++ b/Sources/CodeEditTextView/Filters/STTextViewController+TextFormation.swift
@@ -71,7 +71,7 @@ extension STTextViewController {
     ///   - whitespaceProvider: The whitespace providers to use.
     ///   - indentationUnit: The unit of indentation to use.
     private func setUpNewlineTabFilters(whitespaceProvider: WhitespaceProviders, indentationUnit: String) {
-        let newlineFilter: Filter = NewlineFilter(whitespaceProviders: whitespaceProvider)
+        let newlineFilter: Filter = NewlineProcessingFilter(whitespaceProviders: whitespaceProvider)
         let tabReplacementFilter: Filter = TabReplacementFilter(indentationUnit: indentationUnit)
 
         textFilters.append(contentsOf: [newlineFilter, tabReplacementFilter])

--- a/Sources/CodeEditTextView/Highlighting/HighlightProviding.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlightProviding.swift
@@ -17,6 +17,9 @@ public protocol HighlightProviding {
     /// - Note: This does not need to be *globally* unique, merely unique across all the highlighters used.
     var identifier: String { get }
 
+    /// Called once at editor initialization.
+    func setUp(textView: HighlighterTextView)
+
     /// Updates the highlighter's code language.
     /// - Parameters:
     ///   - codeLanguage: The langugage that should be used by the highlighter.

--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -88,6 +88,7 @@ class Highlighter: NSObject {
         }
 
         textView.textContentStorage.textStorage?.delegate = self
+        highlightProvider?.setUp(textView: textView)
 
         if let scrollView = textView.enclosingScrollView {
             NotificationCenter.default.addObserver(self,
@@ -121,6 +122,7 @@ class Highlighter: NSObject {
     public func setHighlightProvider(_ provider: HighlightProviding) {
         self.highlightProvider = provider
         highlightProvider?.setLanguage(codeLanguage: language)
+        highlightProvider?.setUp(textView: textView)
         invalidate()
     }
 

--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -282,7 +282,7 @@ extension Highlighter: NSTextStorageDelegate {
                                      delta: delta) { [weak self] invalidatedIndexSet in
             let indexSet = invalidatedIndexSet
                 .union(IndexSet(integersIn: editedRange))
-                // Only invalidate indices that aren't visible.
+                // Only invalidate indices that are visible.
                 .intersection(self?.visibleSet ?? .init())
 
             for range in indexSet.rangeView {

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Edit.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Edit.swift
@@ -1,0 +1,86 @@
+//
+//  TreeSitterClient+Edit.swift
+//  
+//
+//  Created by Khan Winter on 3/10/23.
+//
+
+import Foundation
+import SwiftTreeSitter
+import CodeEditLanguages
+
+extension TreeSitterClient {
+
+    /// Calculates a series of ranges that have been invalidated by a given edit.
+    /// - Parameters:
+    ///   - textView: The text view to use for text.
+    ///   - edit: The edit to act on.
+    ///   - language: The language to use.
+    ///   - readBlock: A callback for fetching blocks of text.
+    /// - Returns: An array of distinct `NSRanges` that need to be re-highlighted.
+    func findChangedByteRanges(textView: HighlighterTextView,
+                               edit: InputEdit,
+                               layer: LanguageLayer,
+                               readBlock: @escaping Parser.ReadBlock) -> [NSRange] {
+        let (oldTree, newTree) = calculateNewState(tree: layer.tree,
+                                                   parser: layer.parser,
+                                                   edit: edit,
+                                                   readBlock: readBlock)
+        if oldTree == nil && newTree == nil {
+            // There was no existing tree, make a new one and return all indexes.
+            layer.tree = createTree(parser: layer.parser, readBlock: readBlock)
+            return [NSRange(textView.documentRange.intRange)]
+        }
+
+        let ranges = changedByteRanges(oldTree, rhs: newTree).map { $0.range }
+
+        layer.tree = newTree
+
+        return ranges
+    }
+
+    /// Applies the edit to the current `tree` and returns the old tree and a copy of the current tree with the
+    /// processed edit.
+    /// - Parameters:
+    ///   - tree: The tree before an edit used to parse the new tree.
+    ///   - parser: The parser used to parse the new tree.
+    ///   - edit: The edit to apply.
+    ///   - readBlock: The block to use to read text.
+    /// - Returns: (The old state, the new state).
+    internal func calculateNewState(tree: Tree?,
+                                    parser: Parser,
+                                    edit: InputEdit,
+                                    readBlock: @escaping Parser.ReadBlock) -> (Tree?, Tree?) {
+        guard let oldTree = tree else {
+            return (nil, nil)
+        }
+        semaphore.wait()
+
+        // Apply the edit to the old tree
+        oldTree.edit(edit)
+
+        let newTree = parser.parse(tree: oldTree, readBlock: readBlock)
+
+        semaphore.signal()
+
+        return (oldTree.copy(), newTree)
+    }
+
+    /// Calculates the changed byte ranges between two trees.
+    /// - Parameters:
+    ///   - lhs: The first (older) tree.
+    ///   - rhs: The second (newer) tree.
+    /// - Returns: Any changed ranges.
+    internal func changedByteRanges(_ lhs: Tree?, rhs: Tree?) -> [Range<UInt32>] {
+        switch (lhs, rhs) {
+        case (let t1?, let t2?):
+            return t1.changedRanges(from: t2).map({ $0.bytes })
+        case (nil, let t2?):
+            let range = t2.rootNode?.byteRange
+
+            return range.flatMap({ [$0] }) ?? []
+        case (_, nil):
+            return []
+        }
+    }
+}

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Edit.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Edit.swift
@@ -18,14 +18,18 @@ extension TreeSitterClient {
     ///   - language: The language to use.
     ///   - readBlock: A callback for fetching blocks of text.
     /// - Returns: An array of distinct `NSRanges` that need to be re-highlighted.
-    func findChangedByteRanges(textView: HighlighterTextView,
-                               edit: InputEdit,
-                               layer: LanguageLayer,
-                               readBlock: @escaping Parser.ReadBlock) -> [NSRange] {
-        let (oldTree, newTree) = calculateNewState(tree: layer.tree,
-                                                   parser: layer.parser,
-                                                   edit: edit,
-                                                   readBlock: readBlock)
+    func findChangedByteRanges(
+        textView: HighlighterTextView,
+        edit: InputEdit,
+        layer: LanguageLayer,
+        readBlock: @escaping Parser.ReadBlock
+    ) -> [NSRange] {
+        let (oldTree, newTree) = calculateNewState(
+            tree: layer.tree,
+            parser: layer.parser,
+            edit: edit,
+            readBlock: readBlock
+        )
         if oldTree == nil && newTree == nil {
             // There was no existing tree, make a new one and return all indexes.
             layer.tree = createTree(parser: layer.parser, readBlock: readBlock)
@@ -47,10 +51,12 @@ extension TreeSitterClient {
     ///   - edit: The edit to apply.
     ///   - readBlock: The block to use to read text.
     /// - Returns: (The old state, the new state).
-    internal func calculateNewState(tree: Tree?,
-                                    parser: Parser,
-                                    edit: InputEdit,
-                                    readBlock: @escaping Parser.ReadBlock) -> (Tree?, Tree?) {
+    internal func calculateNewState(
+        tree: Tree?,
+        parser: Parser,
+        edit: InputEdit,
+        readBlock: @escaping Parser.ReadBlock
+    ) -> (Tree?, Tree?) {
         guard let oldTree = tree else {
             return (nil, nil)
         }
@@ -96,11 +102,13 @@ extension TreeSitterClient {
     ///   - readBlock: A completion block for reading from text storage efficiently.
     /// - Returns: An index set of any updated indexes.
     @discardableResult
-    internal func updateInjectedLanguageLayers(textView: HighlighterTextView,
-                                               layer: LanguageLayer,
-                                               layerSet: inout Set<LanguageLayer>,
-                                               touchedLayers: inout Set<LanguageLayer>,
-                                               readBlock: @escaping Parser.ReadBlock) -> IndexSet {
+    internal func updateInjectedLanguageLayers(
+        textView: HighlighterTextView,
+        layer: LanguageLayer,
+        layerSet: inout Set<LanguageLayer>,
+        touchedLayers: inout Set<LanguageLayer>,
+        readBlock: @escaping Parser.ReadBlock
+    ) -> IndexSet {
         guard let tree = layer.tree,
               let rootNode = tree.rootNode,
               let cursor = layer.languageQuery?.execute(node: rootNode, in: tree) else {
@@ -126,10 +134,12 @@ extension TreeSitterClient {
 
             for range in ranges {
                 // Temp layer object for
-                let layer = LanguageLayer(id: treeSitterLanguage,
-                                          parser: Parser(),
-                                          supportsInjections: false,
-                                          ranges: [range.range])
+                let layer = LanguageLayer(
+                    id: treeSitterLanguage,
+                    parser: Parser(),
+                    supportsInjections: false,
+                    ranges: [range.range]
+                )
 
                 if layerSet.contains(layer) {
                     // If we've found this layer, it means it should exist after an edit.

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Highlight.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Highlight.swift
@@ -17,9 +17,11 @@ extension TreeSitterClient {
     ///   - textView: A text view to use for contextual data.
     ///   - range: The range to query for.
     /// - Returns: Any ranges to highlight.
-    internal func queryLayerHighlights(layer: LanguageLayer,
-                                       textView: HighlighterTextView,
-                                       range: NSRange) -> [HighlightRange] {
+    internal func queryLayerHighlights(
+        layer: LanguageLayer,
+        textView: HighlighterTextView,
+        range: NSRange
+    ) -> [HighlightRange] {
         // Make sure we don't change the tree while we copy it.
         self.semaphore.wait()
 

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Highlight.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Highlight.swift
@@ -1,0 +1,145 @@
+//
+//  TreeSitterClient+Highlight.swift
+//  
+//
+//  Created by Khan Winter on 3/10/23.
+//
+
+import Foundation
+import SwiftTreeSitter
+import CodeEditLanguages
+
+extension TreeSitterClient {
+
+    /// Queries the given language layer for any highlights.
+    /// - Parameters:
+    ///   - layer: The layer to query.
+    ///   - textView: A text view to use for contextual data.
+    ///   - range: The range to query for.
+    /// - Returns: Any ranges to highlight.
+    internal func queryLayerHighlights(layer: LanguageLayer,
+                                       textView: HighlighterTextView,
+                                       range: NSRange) -> [HighlightRange] {
+        // Make sure we don't change the tree while we copy it.
+        self.semaphore.wait()
+
+        guard let tree = layer.tree?.copy() else {
+            self.semaphore.signal()
+            return []
+        }
+
+        self.semaphore.signal()
+
+        guard let rootNode = tree.rootNode else {
+            return []
+        }
+
+        // This needs to be on the main thread since we're going to use the `textProvider` in
+        // the `highlightsFromCursor` method, which uses the textView's text storage.
+        guard let cursor = layer.languageQuery?.execute(node: rootNode, in: tree) else {
+            return []
+        }
+        cursor.setRange(range)
+        cursor.matchLimit = Constants.treeSitterMatchLimit
+
+        return highlightsFromCursor(cursor: ResolvingQueryCursor(cursor: cursor))
+    }
+
+    /// Performs an injections query on the given language layer.
+    /// Updates any existing layers with new ranges and adds new layers if needed.
+    /// - Parameters:
+    ///   - textView: The text view to use.
+    ///   - language: The language layer to perform the query on.
+    ///   - readBlock: A completion block for reading from text storage efficiently.
+    /// - Returns: An index set of any updated indexes.
+    @discardableResult
+    internal func updateInjectedLanguageLayers(textView: HighlighterTextView,
+                                               language: LanguageLayer,
+                                               readBlock: @escaping Parser.ReadBlock) -> IndexSet {
+        guard let tree = language.tree,
+              let rootNode = tree.rootNode,
+              let cursor = language.languageQuery?.execute(node: rootNode, in: tree) else {
+            return IndexSet()
+        }
+
+        cursor.matchLimit = Constants.treeSitterMatchLimit
+
+        let languageRanges = self.injectedLanguagesFrom(cursor: cursor) { range, _ in
+            return textView.stringForRange(range)
+        }
+
+        var updatedRanges = IndexSet()
+        for (languageName, ranges) in languageRanges {
+            guard let treeSitterLanguage = TreeSitterLanguage(rawValue: languageName) else {
+                continue
+            }
+
+            if treeSitterLanguage == primaryLayer {
+                continue
+            }
+
+            // Add the language if not available
+            if let layerIndex = layers.firstIndex(where: { $0.id == treeSitterLanguage }) {
+                // Add any ranges not included in the layer already
+                for range in ranges where !layers[layerIndex].ranges.contains(range.range) {
+                    updatedRanges.insert(range: range.range)
+                    layers[layerIndex].ranges.append(range.range)
+                }
+            } else {
+                addLanguageLayer(layerId: treeSitterLanguage, readBlock: readBlock)
+
+                let layerIndex = layers.count - 1
+                guard layers.last?.id == treeSitterLanguage else {
+                    continue
+                }
+
+                layers[layerIndex].parser.includedRanges = ranges.map { $0.tsRange }
+                layers[layerIndex].ranges = ranges.map { $0.range }
+            }
+        }
+        return updatedRanges
+    }
+
+    /// Resolves a query cursor to the highlight ranges it contains.
+    /// **Must be called on the main thread**
+    /// - Parameter cursor: The cursor to resolve.
+    /// - Returns: Any highlight ranges contained in the cursor.
+    internal func highlightsFromCursor(cursor: ResolvingQueryCursor) -> [HighlightRange] {
+        cursor.prepare(with: self.textProvider)
+        return cursor
+            .flatMap { $0.captures }
+            .compactMap {
+                // Some languages add an "@spell" capture to indicate a portion of text that should be spellchecked
+                // (usually comments). But this causes other captures in the same range to be overriden. So we ignore
+                // that specific capture type.
+                if $0.name != "spell" && $0.name != "injection.content" {
+                    return HighlightRange(range: $0.range, capture: CaptureName.fromString($0.name ?? ""))
+                }
+                return nil
+            }
+    }
+
+    /// Returns all injected languages from a given cursor. The cursor must be new,
+    /// having not been used for normal highlight matching.
+    /// - Parameters:
+    ///   - cursor: The cursor to use for finding injected languages.
+    ///   - textProvider: A callback for efficiently fetching text.
+    /// - Returns: A map of each language to all the ranges they have been injected into.
+    internal func injectedLanguagesFrom(
+        cursor: QueryCursor,
+        textProvider: @escaping ResolvingQueryCursor.TextProvider
+    ) -> [String: [NamedRange]] {
+        var languages: [String: [NamedRange]] = [:]
+
+        for match in cursor {
+            if let injection = match.injection(with: textProvider) {
+                if languages[injection.name] == nil {
+                    languages[injection.name] = []
+                }
+                languages[injection.name]?.append(injection)
+            }
+        }
+
+        return languages
+    }
+}

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Highlight.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+Highlight.swift
@@ -78,14 +78,15 @@ extension TreeSitterClient {
                 continue
             }
 
-            // Add the language if not available
-            if let layerIndex = layers.firstIndex(where: { $0.id == treeSitterLanguage }) {
+            if let layer = layers.first(where: { $0.id == treeSitterLanguage }) {
                 // Add any ranges not included in the layer already
-                for range in ranges where !layers[layerIndex].ranges.contains(range.range) {
-                    updatedRanges.insert(range: range.range)
-                    layers[layerIndex].ranges.append(range.range)
+                for namedRange in ranges
+                where !layer.ranges.contains(where: { $0.intersection(namedRange.range) != nil }) {
+                    updatedRanges.insert(range: namedRange.range)
+                    layer.ranges.append(namedRange.range)
                 }
             } else {
+                // Add the language if not available
                 addLanguageLayer(layerId: treeSitterLanguage, readBlock: readBlock)
 
                 let layerIndex = layers.count - 1
@@ -95,6 +96,7 @@ extension TreeSitterClient {
 
                 layers[layerIndex].parser.includedRanges = ranges.map { $0.tsRange }
                 layers[layerIndex].ranges = ranges.map { $0.range }
+                layers[layerIndex].tree = createTree(parser: layers[layerIndex].parser, readBlock: readBlock)
             }
         }
         return updatedRanges

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
@@ -23,8 +23,8 @@ extension TreeSitterClient {
             self.ranges = ranges
         }
 
-        var id: TreeSitterLanguage
-        var parser: Parser
+        let id: TreeSitterLanguage
+        let parser: Parser
         var tree: Tree?
         var languageQuery: Query?
         var ranges: [NSRange]

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
@@ -28,6 +28,5 @@ extension TreeSitterClient {
         var tree: Tree?
         var languageQuery: Query?
         var ranges: [NSRange]
-        var color: CaptureName = [.string, .boolean, .number].randomElement()!
     }
 }

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
@@ -19,12 +19,14 @@ extension TreeSitterClient {
         ///   - tree: The tree-sitter tree generated while editing/parsing a document.
         ///   - languageQuery: The language query used for fetching the associated `queries.scm` file
         ///   - ranges: All ranges this layer acts on. Must be kept in order and w/o overlap.
-        init(id: TreeSitterLanguage,
-             parser: Parser,
-             supportsInjections: Bool,
-             tree: Tree? = nil,
-             languageQuery: Query? = nil,
-             ranges: [NSRange]) {
+        init(
+            id: TreeSitterLanguage,
+            parser: Parser,
+            supportsInjections: Bool,
+            tree: Tree? = nil,
+            languageQuery: Query? = nil,
+            ranges: [NSRange]
+        ) {
             self.id = id
             self.parser = parser
             self.supportsInjections = supportsInjections

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
@@ -1,0 +1,33 @@
+//
+//  TreeSitterClient+LanguageLayer.swift
+//  
+//
+//  Created by Khan Winter on 3/8/23.
+//
+
+import Foundation
+import CodeEditLanguages
+import SwiftTreeSitter
+
+extension TreeSitterClient {
+    class LanguageLayer {
+        init(id: TreeSitterLanguage,
+             parser: Parser,
+             tree: Tree? = nil,
+             languageQuery: Query? = nil,
+             ranges: [NSRange]) {
+            self.id = id
+            self.parser = parser
+            self.tree = tree
+            self.languageQuery = languageQuery
+            self.ranges = ranges
+        }
+
+        var id: TreeSitterLanguage
+        var parser: Parser
+        var tree: Tree?
+        var languageQuery: Query?
+        var ranges: [NSRange]
+        var color: CaptureName = [.string, .boolean, .number].randomElement()!
+    }
+}

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient+LanguageLayer.swift
@@ -10,14 +10,24 @@ import CodeEditLanguages
 import SwiftTreeSitter
 
 extension TreeSitterClient {
-    class LanguageLayer {
+    class LanguageLayer: Hashable {
+        /// Initialize a language layer
+        /// - Parameters:
+        ///   - id: The ID of the layer.
+        ///   - parser: A parser to use for the layer.
+        ///   - supportsInjections: Set to true when the langauge supports the `injections` query.
+        ///   - tree: The tree-sitter tree generated while editing/parsing a document.
+        ///   - languageQuery: The language query used for fetching the associated `queries.scm` file
+        ///   - ranges: All ranges this layer acts on. Must be kept in order and w/o overlap.
         init(id: TreeSitterLanguage,
              parser: Parser,
+             supportsInjections: Bool,
              tree: Tree? = nil,
              languageQuery: Query? = nil,
              ranges: [NSRange]) {
             self.id = id
             self.parser = parser
+            self.supportsInjections = supportsInjections
             self.tree = tree
             self.languageQuery = languageQuery
             self.ranges = ranges
@@ -25,8 +35,18 @@ extension TreeSitterClient {
 
         let id: TreeSitterLanguage
         let parser: Parser
+        let supportsInjections: Bool
         var tree: Tree?
         var languageQuery: Query?
         var ranges: [NSRange]
+
+        static func == (lhs: TreeSitterClient.LanguageLayer, rhs: TreeSitterClient.LanguageLayer) -> Bool {
+            return lhs.id == rhs.id && lhs.ranges == rhs.ranges
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(id)
+            hasher.combine(ranges)
+        }
     }
 }

--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
@@ -226,7 +226,7 @@ final class TreeSitterClient: HighlightProviding {
         let languageRanges = self.injectedLanguagesFrom(cursor: cursor) { range, _ in
             return textView.stringForRange(range)
         }
-        
+
         var highlights: [HighlightRange] = []
 
         for (languageName, ranges) in languageRanges {


### PR DESCRIPTION
# Description

This PR adds support for injected languages using tree-sitter as described in #16 and in the [tree-sitter documentation](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection). Languages can contain _injected_ languages which are described in a language's `injections.scm` file. Some examples of injected languages are:
- HTML contains CSS and Javascript in `style` and `script` tags
- Javascript contains Regex literals
- PHP contains HTML between the `<php` tags
- C++ can contain rawstring literals of arbitrary languages

# Details

This PR is a rework of the `TreeSitterClient` class. Specifically it:
- Adds a `layers` array and `primaryLayer` property. `layers` contains all language layers in the document, and `primaryLayer` is the ID of the document's primary language.
- Each layer is a `LanguageLayer` object. These objects represent an injected language-range(s) combination. Each layer can have one or more range associated with it depending on if it should be [parsed as one document or multiple](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection).
- When editing:
  - Each layer's ranges are updated using a similar algorithm to tree-sitter, and edits are applied to make use of the incremental parsing tree-sitter gives.
  - Each layer is checked for any injections, inserting any new injected layers and keeping track of any 'untouched' layers to remove.
  - Any layers that were not touched are removed.

The highlight query algorithm is largely the same, but keeps track of any ranges not used by any injected layers, and only queries the primary layer for those ranges so as not to override any injected highlights.

# Related Issues

- Closes #16 

# Screenshots

Before, other languages were detected but parsed and highlighted as normal text.
<img width="1104" alt="Screenshot 2023-02-28 at 3 08 52 PM" src="https://user-images.githubusercontent.com/35942988/221980502-3aa61b6a-136a-43b9-a545-8fd835945002.png">

With Injected languages, in this case CSS and JS embedded in HTML and a second layer of Regex embedded in JS embedded in HTML:
<img width="889" alt="Screenshot 2023-03-24 at 2 45 15 PM" src="https://user-images.githubusercontent.com/35942988/227628557-df55d986-a104-4a24-ab6c-97c8e69f6136.png">

