### PR TITLE
Fixes text binding update

### DIFF
--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -183,7 +183,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         super.viewDidAppear()
     }
 
-    public func textDidChange(_ notification: Notification) {
+    public func textViewDidChangeText(_ notification: Notification) {
         self.text.wrappedValue = textView.string
     }
 


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

The STTextViewDelegate  textDidChange function changed to textViewDidChangeText. Without this change, the text binding value wasn't updated.

Before, in a situation like the one below, the prompt variable was never updated since the delegate function was not called because of the mismatched signature.
```
@State var prompt: String = "..."
(...)

 CodeEditTextView(
    $prompt,
    language: .default,
    theme: $theme,
    font: $font,
    tabWidth: $tabWidth,
    lineHeight: $lineHeight, wrapLines: .constant(true),
    editorOverscroll: $editorOverscroll
)
.onChange(of: prompt, perform: { promptUpdate in
    print(promptUpdate)
})
```

With the proposed update, the behaviour is as expected. The `onChange` is now triggered.

The STTextViewDelegate: [https://github.com/krzyzanowskim/STTextView/blob/main/Sources/STTextView/STTextViewDelegate.swift](https://github.com/krzyzanowskim/STTextView/blob/main/Sources/STTextView/STTextViewDelegate.swift)

<!--- REQUIRED: Describe what changed in detail -->

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [ ] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] My changes are all related to the related issue above
- [x] I documented my code