### PR TITLE
Optionally set text view to read only

### DIFF
--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -27,6 +27,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///                        built-in `TreeSitterClient` highlighter.
     ///   - contentInsets: Insets to use to offset the content in the enclosing scroll view. Leave as `nil` to let the
     ///                    scroll view automatically adjust content insets.
+    ///   - isEditable: A Boolean value that controls whether the text view allows the user to edit text.
     public init(
         _ text: Binding<String>,
         language: CodeLanguage,
@@ -39,7 +40,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         cursorPosition: Published<(Int, Int)>.Publisher? = nil,
         useThemeBackground: Bool = true,
         highlightProvider: HighlightProviding? = nil,
-        contentInsets: NSEdgeInsets? = nil
+        contentInsets: NSEdgeInsets? = nil,
+        isEditable: Bool = true
     ) {
         self._text = text
         self.language = language
@@ -53,6 +55,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self.cursorPosition = cursorPosition
         self.highlightProvider = highlightProvider
         self.contentInsets = contentInsets
+        self.isEditable = isEditable
     }
 
     @Binding private var text: String
@@ -67,6 +70,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     private var useThemeBackground: Bool
     private var highlightProvider: HighlightProviding?
     private var contentInsets: NSEdgeInsets?
+    private var isEditable: Bool
 
     public typealias NSViewControllerType = STTextViewController
 
@@ -82,7 +86,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             editorOverscroll: editorOverscroll,
             useThemeBackground: useThemeBackground,
             highlightProvider: highlightProvider,
-            contentInsets: contentInsets
+            contentInsets: contentInsets,
+            isEditable: isEditable
         )
         controller.lineHeightMultiple = lineHeight
         return controller

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -137,10 +137,10 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView.backgroundColor = useThemeBackground ? theme.background : .clear
         textView.insertionPointColor = theme.insertionPoint
         textView.insertionPointWidth = 1.0
-        textView.isEditable = self.isEditable
         textView.selectionBackgroundColor = theme.selection
         textView.selectedLineHighlightColor = theme.lineHighlight
         textView.string = self.text.wrappedValue
+        textView.isEditable = self.isEditable
         textView.widthTracksTextView = self.wrapLines
         textView.highlightSelectedLine = true
         textView.allowsUndo = true
@@ -229,6 +229,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView?.insertionPointColor = theme.insertionPoint
         textView?.selectionBackgroundColor = theme.selection
         textView?.selectedLineHighlightColor = theme.lineHighlight
+        textView?.isEditable = isEditable
 
         rulerView?.backgroundColor = useThemeBackground ? theme.background : .clear
         rulerView?.separatorColor = theme.invisibles

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -128,7 +128,10 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
         rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
-        rulerView.highlightSelectedLine = self.isEditable
+
+        if self.isEditable == false {
+            rulerView.selectedLineTextColor = nil
+        }
 
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -128,6 +128,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
         rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
+        rulerView.highlightSelectedLine = self.isEditable
+
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true
 
@@ -146,6 +148,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView.allowsUndo = true
         textView.setupMenus()
         textView.delegate = self
+        textView.highlightSelectedLine = self.isEditable
 
         scrollView.documentView = textView
 
@@ -230,10 +233,12 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView?.selectionBackgroundColor = theme.selection
         textView?.selectedLineHighlightColor = theme.lineHighlight
         textView?.isEditable = isEditable
+        textView.highlightSelectedLine = isEditable
 
         rulerView?.backgroundColor = useThemeBackground ? theme.background : .clear
         rulerView?.separatorColor = theme.invisibles
         rulerView?.baselineOffset = baselineOffset
+        rulerView.highlightSelectedLine = isEditable
 
         if let scrollView = view as? NSScrollView {
             scrollView.drawsBackground = useThemeBackground

--- a/Sources/CodeEditTextView/STTextViewController.swift
+++ b/Sources/CodeEditTextView/STTextViewController.swift
@@ -52,6 +52,9 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     /// Whether lines wrap to the width of the editor
     public var wrapLines: Bool
 
+    /// Whether or not text view is editable by user
+    public var isEditable: Bool
+
     /// Filters used when applying edits..
     internal var textFilters: [TextFormation.Filter] = []
 
@@ -81,7 +84,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         editorOverscroll: Double,
         useThemeBackground: Bool,
         highlightProvider: HighlightProviding? = nil,
-        contentInsets: NSEdgeInsets? = nil
+        contentInsets: NSEdgeInsets? = nil,
+        isEditable: Bool
     ) {
         self.text = text
         self.language = language
@@ -94,6 +98,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         self.useThemeBackground = useThemeBackground
         self.highlightProvider = highlightProvider
         self.contentInsets = contentInsets
+        self.isEditable = isEditable
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -132,6 +137,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView.backgroundColor = useThemeBackground ? theme.background : .clear
         textView.insertionPointColor = theme.insertionPoint
         textView.insertionPointWidth = 1.0
+        textView.isEditable = self.isEditable
         textView.selectionBackgroundColor = theme.selection
         textView.selectedLineHighlightColor = theme.lineHighlight
         textView.string = self.text.wrappedValue

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -35,7 +35,8 @@ final class STTextViewControllerTests: XCTestCase {
             tabWidth: 4,
             wrapLines: true,
             editorOverscroll: 0.5,
-            useThemeBackground: true
+            useThemeBackground: true,
+            isEditable: true
         )
     }
 


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

This PR adds `isEditable` to pass through to STTextView. Setting this to `false` makes the text view read-only.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
