### PR TITLE
Make ruler look more like Xcode.

### DIFF
--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -252,6 +252,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
         rulerView?.backgroundColor = useThemeBackground ? theme.background : .clear
         rulerView?.separatorColor = theme.invisibles
+        rulerView?.selectedLineHighlightColor = theme.lineHighlight
         rulerView?.baselineOffset = baselineOffset
         rulerView.highlightSelectedLine = isEditable
 

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -131,9 +131,12 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView.drawSeparator = false
         rulerView.baselineOffset = baselineOffset
         rulerView.font = NSFont.monospacedDigitSystemFont(ofSize: 9.5, weight: .regular)
+        rulerView.selectedLineHighlightColor = theme.lineHighlight
+        rulerView.rulerInsets = STRulerInsets(leading: 20, trailing: 8)
 
         if self.isEditable == false {
             rulerView.selectedLineTextColor = nil
+            rulerView.selectedLineHighlightColor = theme.background
         }
 
         scrollView.verticalRulerView = rulerView


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

1. Add 20 pixels of inset to the left of the ruler and 8 pixels of inset to the right of the ruler. I tried to match it as close as possible to Xcode.
2. Set the background color of the highlight ruler line to the same color as the highlighted line in the textView.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #156
* closes #128

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<img width="765" alt="Screenshot 2023-03-16 at 19 05 59" src="https://user-images.githubusercontent.com/82230675/225717006-40530a7b-7864-404b-8d14-5307f6f83bdb.png">


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
