### PR TITLE
[chore]: Update CodeEditLanguages to `0.1.13`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "02595fb02841568b9befcbfcdaf9be88280c49aa",
-        "version" : "0.1.11"
+        "revision" : "08cb9dc04e70d1e7b9610580794ed4da774c2b84",
+        "version" : "0.1.13"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",
-            exact: "0.1.11"
+            exact: "0.1.13"
         ),
         .package(
             url: "https://github.com/lukepistrol/SwiftLintPlugin",


### PR DESCRIPTION
- implements parsers for `Regex` and `Dart`