### PR TITLE
Indent Options and Clarify Tab Width

### DIFF
--- a/Sources/CodeEditTextView/CodeEditTextView.swift
+++ b/Sources/CodeEditTextView/CodeEditTextView.swift
@@ -18,7 +18,8 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     ///   - language: The language for syntax highlighting
     ///   - theme: The theme for syntax highlighting
     ///   - font: The default font
-    ///   - tabWidth: The tab width
+    ///   - tabWidth: The visual tab width in number of spaces
+    ///   - indentOption: The behavior to use when the tab key is pressed. Defaults to 4 spaces.
     ///   - lineHeight: The line height multiplier (e.g. `1.2`)
     ///   - wrapLines: Whether lines wrap to the width of the editor
     ///   - editorOverscroll: The percentage for overscroll, between 0-1 (default: `0.0`)
@@ -33,6 +34,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         theme: Binding<EditorTheme>,
         font: Binding<NSFont>,
         tabWidth: Binding<Int>,
+        indentOption: Binding<IndentOption> = .constant(.spaces(count: 4)),
         lineHeight: Binding<Double>,
         wrapLines: Binding<Bool>,
         editorOverscroll: Binding<Double> = .constant(0.0),
@@ -48,6 +50,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
         self.useThemeBackground = useThemeBackground
         self._font = font
         self._tabWidth = tabWidth
+        self._indentOption = indentOption
         self._lineHeight = lineHeight
         self._wrapLines = wrapLines
         self._editorOverscroll = editorOverscroll
@@ -62,6 +65,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
     @Binding private var theme: EditorTheme
     @Binding private var font: NSFont
     @Binding private var tabWidth: Int
+    @Binding private var indentOption: IndentOption
     @Binding private var lineHeight: Double
     @Binding private var wrapLines: Bool
     @Binding private var editorOverscroll: Double
@@ -80,6 +84,7 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
             font: font,
             theme: theme,
             tabWidth: tabWidth,
+            indentOption: indentOption,
             wrapLines: wrapLines,
             cursorPosition: $cursorPosition,
             editorOverscroll: editorOverscroll,
@@ -94,19 +99,24 @@ public struct CodeEditTextView: NSViewControllerRepresentable {
 
     public func updateNSViewController(_ controller: NSViewControllerType, context: Context) {
         controller.font = font
-        controller.tabWidth = tabWidth
         controller.wrapLines = wrapLines
         controller.useThemeBackground = useThemeBackground
         controller.lineHeightMultiple = lineHeight
         controller.editorOverscroll = editorOverscroll
         controller.contentInsets = contentInsets
 
-        // Updating the language and theme needlessly can cause highlights to be re-calculated.
+        // Updating the language, theme, tab width and indent option needlessly can cause highlights to be re-calculated
         if controller.language.id != language.id {
             controller.language = language
         }
         if controller.theme != theme {
             controller.theme = theme
+        }
+        if controller.indentOption != indentOption {
+            controller.indentOption = indentOption
+        }
+        if controller.tabWidth != tabWidth {
+            controller.tabWidth = tabWidth
         }
 
         controller.reloadUI()

--- a/Sources/CodeEditTextView/Enums/IndentOption.swift
+++ b/Sources/CodeEditTextView/Enums/IndentOption.swift
@@ -1,0 +1,32 @@
+//
+//  IndentOption.swift
+//
+//
+//  Created by Khan Winter on 3/26/23.
+//
+
+/// Represents what to insert on a tab key press.
+public enum IndentOption: Equatable {
+    case spaces(count: Int)
+    case tab
+
+    var stringValue: String {
+        switch self {
+        case .spaces(let count):
+            return String(repeating: " ", count: count)
+        case .tab:
+            return "\t"
+        }
+    }
+
+    public static func == (lhs: IndentOption, rhs: IndentOption) -> Bool {
+        switch (lhs, rhs) {
+        case (.tab, .tab):
+            return true
+        case (.spaces(let lhsCount), .spaces(let rhsCount)):
+            return lhsCount == rhsCount
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+TextInterface.swift
+++ b/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+TextInterface.swift
@@ -42,5 +42,7 @@ extension STTextView: TextInterface {
         textContentStorage.performEditingTransaction {
             textContentStorage.applyMutation(mutation)
         }
+
+        didChangeText()
     }
 }

--- a/Sources/CodeEditTextView/Filters/DeleteWhitespaceFilter.swift
+++ b/Sources/CodeEditTextView/Filters/DeleteWhitespaceFilter.swift
@@ -11,10 +11,10 @@ import TextStory
 
 /// Filter for quickly deleting indent whitespace
 struct DeleteWhitespaceFilter: Filter {
-    let indentationUnit: String
+    let indentOption: IndentOption
 
     func processMutation(_ mutation: TextMutation, in interface: TextInterface) -> FilterAction {
-        guard mutation.string == "" && mutation.range.length == 1 else {
+        guard mutation.string == "" && mutation.range.length == 1 && indentOption != .tab else {
             return .none
         }
 
@@ -26,13 +26,14 @@ struct DeleteWhitespaceFilter: Filter {
             return .none
         }
 
+        let indentLength = indentOption.stringValue.count
         let length = mutation.range.max - preceedingNonWhitespace
-        let numberOfExtraSpaces = length % indentationUnit.count
+        let numberOfExtraSpaces = length % indentLength
 
-        if numberOfExtraSpaces == 0 && length >= indentationUnit.count {
+        if numberOfExtraSpaces == 0 && length >= indentLength {
             interface.applyMutation(
-                TextMutation(delete: NSRange(location: mutation.range.max - indentationUnit.count,
-                                             length: indentationUnit.count),
+                TextMutation(delete: NSRange(location: mutation.range.max - indentLength,
+                                             length: indentLength),
                              limit: mutation.limit)
             )
             return .discard

--- a/Sources/CodeEditTextView/Filters/STTextViewController+TextFormation.swift
+++ b/Sources/CodeEditTextView/Filters/STTextViewController+TextFormation.swift
@@ -18,7 +18,7 @@ extension STTextViewController {
     internal func setUpTextFormation() {
         textFilters = []
 
-        let indentationUnit = String(repeating: " ", count: tabWidth)
+        let indentationUnit = indentOption.stringValue
 
         let pairsToHandle: [(String, String)] = [
             ("{", "}"),
@@ -38,9 +38,9 @@ extension STTextViewController {
 
         setUpOpenPairFilters(pairs: pairsToHandle, whitespaceProvider: whitespaceProvider)
         setUpNewlineTabFilters(whitespaceProvider: whitespaceProvider,
-                               indentationUnit: indentationUnit)
+                               indentOption: indentOption)
         setUpDeletePairFilters(pairs: pairsToHandle)
-        setUpDeleteWhitespaceFilter(indentationUnit: indentationUnit)
+        setUpDeleteWhitespaceFilter(indentOption: indentOption)
     }
 
     /// Returns a `TextualIndenter` based on available language configuration.
@@ -70,9 +70,9 @@ extension STTextViewController {
     /// - Parameters:
     ///   - whitespaceProvider: The whitespace providers to use.
     ///   - indentationUnit: The unit of indentation to use.
-    private func setUpNewlineTabFilters(whitespaceProvider: WhitespaceProviders, indentationUnit: String) {
+    private func setUpNewlineTabFilters(whitespaceProvider: WhitespaceProviders, indentOption: IndentOption) {
         let newlineFilter: Filter = NewlineProcessingFilter(whitespaceProviders: whitespaceProvider)
-        let tabReplacementFilter: Filter = TabReplacementFilter(indentationUnit: indentationUnit)
+        let tabReplacementFilter: Filter = TabReplacementFilter(indentOption: indentOption)
 
         textFilters.append(contentsOf: [newlineFilter, tabReplacementFilter])
     }
@@ -86,8 +86,8 @@ extension STTextViewController {
     }
 
     /// Configures up the delete whitespace filter.
-    private func setUpDeleteWhitespaceFilter(indentationUnit: String) {
-        let filter = DeleteWhitespaceFilter(indentationUnit: indentationUnit)
+    private func setUpDeleteWhitespaceFilter(indentOption: IndentOption) {
+        let filter = DeleteWhitespaceFilter(indentOption: indentOption)
         textFilters.append(filter)
     }
 

--- a/Sources/CodeEditTextView/Filters/TabReplacementFilter.swift
+++ b/Sources/CodeEditTextView/Filters/TabReplacementFilter.swift
@@ -12,11 +12,11 @@ import TextStory
 /// Filter for replacing tab characters with the user-defined indentation unit.
 /// - Note: The undentation unit can be another tab character, this is merely a point at which this can be configured.
 struct TabReplacementFilter: Filter {
-    let indentationUnit: String
+    let indentOption: IndentOption
 
     func processMutation(_ mutation: TextMutation, in interface: TextInterface) -> FilterAction {
-        if mutation.string == "\t" {
-            interface.applyMutation(TextMutation(insert: indentationUnit,
+        if mutation.string == "\t" && indentOption != .tab && mutation.delta > 0 {
+            interface.applyMutation(TextMutation(insert: indentOption.stringValue,
                                                  at: mutation.range.location,
                                                  limit: mutation.limit))
             return .discard

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import CodeEditTextView
 import SwiftTreeSitter
 import AppKit
+import TextStory
 
 final class STTextViewControllerTests: XCTestCase {
 
@@ -33,12 +34,15 @@ final class STTextViewControllerTests: XCTestCase {
             font: .monospacedSystemFont(ofSize: 11, weight: .medium),
             theme: theme,
             tabWidth: 4,
+            indentOption: .spaces(count: 4),
             wrapLines: true,
             cursorPosition: .constant((1, 1)),
             editorOverscroll: 0.5,
             useThemeBackground: true,
             isEditable: true
         )
+
+        controller.loadView()
     }
 
     func test_captureNames() throws {
@@ -140,5 +144,54 @@ final class STTextViewControllerTests: XCTestCase {
 
         // editorOverscroll: 0
         XCTAssertEqual(scrollView.contentView.contentInsets.bottom, 0)
+    }
+
+    func test_indentOptionString() {
+        XCTAssertEqual(" ", IndentOption.spaces(count: 1).stringValue)
+        XCTAssertEqual("  ", IndentOption.spaces(count: 2).stringValue)
+        XCTAssertEqual("   ", IndentOption.spaces(count: 3).stringValue)
+        XCTAssertEqual("    ", IndentOption.spaces(count: 4).stringValue)
+        XCTAssertEqual("     ", IndentOption.spaces(count: 5).stringValue)
+
+        XCTAssertEqual("\t", IndentOption.tab.stringValue)
+    }
+
+    func test_indentBehavior() {
+        // Insert 1 space
+        controller.indentOption = .spaces(count: 1)
+        controller.textView.string = ""
+        controller.insertTab(nil)
+        XCTAssertEqual(controller.textView.string, " ")
+
+        // Insert 2 spaces
+        controller.indentOption = .spaces(count: 2)
+        controller.textView.string = ""
+        controller.textView.insertText("\t", replacementRange: .zero)
+        XCTAssertEqual(controller.textView.string, "  ")
+
+        // Insert 3 spaces
+        controller.indentOption = .spaces(count: 3)
+        controller.textView.string = ""
+        controller.textView.insertText("\t", replacementRange: .zero)
+        XCTAssertEqual(controller.textView.string, "   ")
+
+        // Insert 4 spaces
+        controller.indentOption = .spaces(count: 4)
+        controller.textView.string = ""
+        controller.textView.insertText("\t", replacementRange: .zero)
+        XCTAssertEqual(controller.textView.string, "    ")
+
+        // Insert tab
+        controller.indentOption = .tab
+        controller.textView.string = ""
+        controller.textView.insertText("\t", replacementRange: .zero)
+        XCTAssertEqual(controller.textView.string, "\t")
+
+
+        // Insert lots of spaces
+        controller.indentOption = .spaces(count: 1000)
+        controller.textView.string = ""
+        controller.textView.insertText("\t", replacementRange: .zero)
+        XCTAssertEqual(controller.textView.string, String(repeating: " ", count: 1000))
     }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

> This is a near clone of #147, but git got messed up on that branch. This PR improves that branch anyways.

This enables configuration of the behavior when the tab key is pressed. Previously all tabs were converted to spaces and inserted `tabWidth` spaces in place of the tab character. This PR clarifies that the `tabWidth` parameter should be used for the *visual* width of tabs, and adds an `indentOption` parameter that specifies how to handle inserting tab characters.

Adds an `IndentOption` enum with two cases for this behavior:
- `spaces(count: Int)`
- `tab`

If `spaces(count: Int)` is specified, the editor will insert the given number of spaces when the tab key is pressed, otherwise the tab character will be kept.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #80 - Does not close, needs an additional PR for the tab width setting.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://user-images.githubusercontent.com/35942988/228014785-85a20e2e-0465-4767-9d53-b97b4df2e11e.mov
