### PR TITLE
Implement Tab Width

### DIFF
--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -233,10 +233,8 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         let paragraph = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
         paragraph.minimumLineHeight = lineHeight
         paragraph.maximumLineHeight = lineHeight
-        // TODO: Fix Tab widths
-        // This adds tab stops throughout the document instead of only changing the width of tab characters
-//        paragraph.tabStops = [NSTextTab(type: .decimalTabStopType, location: 0.0)]
-//        paragraph.defaultTabInterval = CGFloat(tabWidth) * (" " as NSString).size(withAttributes: [.font: font]).width
+        paragraph.tabStops = [NSTextTab(type: .decimalTabStopType, location: 0.0)]
+        paragraph.defaultTabInterval = CGFloat(tabWidth) * (" " as NSString).size(withAttributes: [.font: font]).width
         return paragraph
     }
 

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -233,7 +233,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         let paragraph = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
         paragraph.minimumLineHeight = lineHeight
         paragraph.maximumLineHeight = lineHeight
-        paragraph.tabStops = [NSTextTab(type: .decimalTabStopType, location: 0.0)]
+        paragraph.tabStops.removeAll()
         paragraph.defaultTabInterval = CGFloat(tabWidth) * (" " as NSString).size(withAttributes: [.font: font]).width
         return paragraph
     }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This PR adds the tab stops implementation. It was previously thought to not function as expected but after comparing to other editors this is the correct implementation. Adding tab stops makes it so tabs stop at intervals along the document, so a tab will not act like a space but rather a break in the line until the next tab stop. Like so:
```
Raw:   |\t1\t2\t3
Visual:|----1---2---3

Raw:   |\tabc\t2\t3
Visual:|----abc-2---3
```

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* Closes #80  

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Screen recording shows the width being updated in real time using a placeholder preference, as well as editing a line with tabs showing the tab stops go backwards only when needed.

https://user-images.githubusercontent.com/35942988/229870857-2cb2e40b-4c61-43ce-96c7-f79a8514cfbd.mov



<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
