### PR TITLE
Add Edits To Visible Range

### DIFF
--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -278,6 +278,9 @@ extension Highlighter: NSTextStorageDelegate {
         }
 
         let range = NSRange(location: editedRange.location, length: editedRange.length - delta)
+        if delta > 0 {
+            visibleSet.insert(range: editedRange)
+        }
 
         highlightProvider?.applyEdit(textView: self.textView,
                                      range: range,


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

<!--- REQUIRED: Describe what changed in detail -->

This change adds all positive edits to the visible range. The assumption is that any edits the user may make are going to be visible at some point in time. If the cursor is not already on the page, it will be scrolled to and if it extends beyond the viewport it will be scrolled to be visible as well. In both of those cases the added range will be overridden immediately due to the scroll. So this fixes the case where characters are being inserted at the end of a file, but aren't being scrolled to. This is apparent in the attached screen recordings.

Alternatives considered:
- **Re-calculating the visible set:** Decided against due to the extra work that would need to be done potentially every keystroke to calculate a new visible range. 
- **Update the visible set only if the edit is actually visible:** Decided against due to the reasons previously mentioned. Any edit will eventually be included in the visible set if it is not already in it when the edit occurs.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #142
* Maybe related to #162

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before fix. Edits applied to the end of the file are never sent to tree-sitter for highlighting as they are out of the range of the visible set. They are only updated when the document is scrolled and `visibleSet` is recalculated.

https://user-images.githubusercontent.com/35942988/229874599-e2714b72-d51f-4748-89e1-b80ee51bddda.mov

After fix. Edits with positive deltas are always included in the `visibleSet`.

https://user-images.githubusercontent.com/35942988/229875515-36e96921-71c0-48aa-a62c-75cbd91c52fb.mov


<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
