### PR TITLE
Update Text Container Width Correctly

### DIFF
--- a/Sources/CodeEditTextView/CEScrollView.swift
+++ b/Sources/CodeEditTextView/CEScrollView.swift
@@ -10,6 +10,12 @@ import STTextView
 
 class CEScrollView: NSScrollView {
 
+    override open var contentSize: NSSize {
+        var proposedSize = super.contentSize
+        proposedSize.width -= verticalRulerView?.requiredThickness ?? 0.0
+        return proposedSize
+    }
+
     override func mouseDown(with event: NSEvent) {
 
         if let textView = self.documentView as? STTextView,

--- a/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
@@ -11,11 +11,13 @@ import SwiftTreeSitter
 extension STTextViewController {
     /// Configures the `Highlighter` object
     internal func setUpHighlighter() {
-        self.highlighter = Highlighter(textView: textView,
-                                       highlightProvider: highlightProvider,
-                                       theme: theme,
-                                       attributeProvider: self,
-                                       language: language)
+        self.highlighter = Highlighter(
+            textView: textView,
+            highlightProvider: highlightProvider,
+            theme: theme,
+            attributeProvider: self,
+            language: language
+        )
     }
 
     /// Sets the highlight provider and re-highlights all text. This method should be used sparingly.

--- a/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
@@ -1,0 +1,40 @@
+//
+//  STTextViewController+Highlighter.swift
+//
+//
+//  Created by Khan Winter on 4/21/23.
+//
+
+import AppKit
+import SwiftTreeSitter
+
+extension STTextViewController {
+    /// Configures the `Highlighter` object
+    internal func setUpHighlighter() {
+        self.highlighter = Highlighter(textView: textView,
+                                       highlightProvider: highlightProvider,
+                                       theme: theme,
+                                       attributeProvider: self,
+                                       language: language)
+    }
+
+    /// Sets the highlight provider and re-highlights all text. This method should be used sparingly.
+    internal func setHighlightProvider(_ highlightProvider: HighlightProviding? = nil) {
+        var provider: HighlightProviding?
+
+        if let highlightProvider = highlightProvider {
+            provider = highlightProvider
+        } else {
+            let textProvider: ResolvingQueryCursor.TextProvider = { [weak self] range, _ -> String? in
+                return self?.textView.textContentStorage.textStorage?.mutableString.substring(with: range)
+            }
+
+            provider = TreeSitterClient(codeLanguage: language, textProvider: textProvider)
+        }
+
+        if let provider = provider {
+            self.highlightProvider = provider
+            highlighter?.setHighlightProvider(provider)
+        }
+    }
+}

--- a/Sources/CodeEditTextView/Controller/STTextViewController+TextContainer.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+TextContainer.swift
@@ -1,0 +1,39 @@
+//
+//  STTextViewController+TextContainer.swift
+//  
+//
+//  Created by Khan Winter on 4/21/23.
+//
+
+import AppKit
+import STTextView
+
+extension STTextViewController {
+    /// Update the text view's text container if needed.
+    ///
+    /// Effectively updates the container to reflect the `wrapLines` setting, and to reflect any updates to the ruler,
+    /// scroll view, or window frames.
+    internal func updateTextContainerWidthIfNeeded() {
+        let previousTrackingSetting = textView.widthTracksTextView
+        textView.widthTracksTextView = wrapLines
+        if wrapLines {
+            var proposedSize = ((view as? NSScrollView)?.contentSize ?? .zero)
+            proposedSize.height = .greatestFiniteMagnitude
+
+            if textView.textContainer.size != proposedSize || textView.frame.size != proposedSize {
+                textView.textContainer.size = proposedSize
+                textView.setFrameSize(proposedSize)
+            }
+        } else {
+            var proposedSize = textView.frame.size
+            proposedSize.width = ((view as? NSScrollView)?.contentSize ?? .zero).width
+            if previousTrackingSetting != wrapLines {
+                textView.textContainer.size = CGSize(
+                    width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude
+                )
+                textView.setFrameSize(proposedSize)
+                textView.textLayoutManager.textViewportLayoutController.layoutViewport()
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

This PR updates the `wrapLines` setting to affect the text view's text container size. This fixes the horizontal scrolling bugs seen recently. In effect, it locks the width of the text view to the width of the visible container when `wrapLines` is set to `true`, and lets the text view determine it's own width when `false`.

This is done by accounting for the ruler view size when `wrapLines` is set to true. It also makes sure to update the text container and text view frame size as needed when the ruler or window size change and when the `wrapLines` setting is updated.

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* #148 
* #158 
* #164 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

https://user-images.githubusercontent.com/35942988/233697019-7b13d78d-b50c-4c61-b58c-28a8695d8a54.mov

