### PR TITLE
[chore]: Update STTextView to `0.5.3`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/krzyzanowskim/STTextView.git",
-            from: "0.4.1"
+            from: "0.5.3"
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",

--- a/Sources/CodeEditTextView/Controller/STTextViewController+Cursor.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Cursor.swift
@@ -31,7 +31,11 @@ extension STTextViewController {
                 line -= 1
                 if line < 1 {
                     // If `column` exceeds the line length, set cursor to the end of the line.
-                    let index = min(lineRange.upperBound, string.index(lineRange.lowerBound, offsetBy: column - 1))
+                    // min = line begining, max = line end.
+                    let index = max(
+                        lineRange.lowerBound,
+                        min(lineRange.upperBound, string.index(lineRange.lowerBound, offsetBy: column - 1))
+                    )
                     if let newRange = NSTextRange(NSRange(index..<index, in: string), provider: provider) {
                         self.textView.setSelectedRange(newRange)
                     }
@@ -46,7 +50,7 @@ extension STTextViewController {
     func updateCursorPosition() {
         guard let textLayoutManager = textView.textLayoutManager as NSTextLayoutManager?,
               let textContentManager = textLayoutManager.textContentManager as NSTextContentManager?,
-              let insertionPointLocation = textLayoutManager.insertionPointLocation,
+              let insertionPointLocation = textLayoutManager.insertionPointLocations.first,
               let documentStartLocation = textLayoutManager.documentRange.location as NSTextLocation?,
               let documentEndLocation = textLayoutManager.documentRange.endLocation as NSTextLocation?
         else {
@@ -96,7 +100,9 @@ extension STTextViewController {
                     if col == 1 { line += 1 }
                 }
 
-                self.cursorPosition.wrappedValue = (line, col)
+                DispatchQueue.main.async {
+                    self.cursorPosition.wrappedValue = (line, col)
+                }
                 return false
             }
         }

--- a/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
@@ -28,7 +28,7 @@ extension STTextViewController {
             provider = highlightProvider
         } else {
             let textProvider: ResolvingQueryCursor.TextProvider = { [weak self] range, _ -> String? in
-                return self?.textView.textContentStorage.textStorage?.mutableString.substring(with: range)
+                return self?.textView.textContentStorage?.textStorage?.mutableString.substring(with: range)
             }
 
             provider = TreeSitterClient(codeLanguage: language, textProvider: textProvider)

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -163,6 +163,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         rulerView.font = rulerFont
         rulerView.selectedLineHighlightColor = theme.lineHighlight
         rulerView.rulerInsets = STRulerInsets(leading: rulerFont.pointSize * 1.6, trailing: 8)
+        rulerView.allowsMarkers = false
 
         if self.isEditable == false {
             rulerView.selectedLineTextColor = nil
@@ -343,7 +344,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
             provider = highlightProvider
         } else {
             let textProvider: ResolvingQueryCursor.TextProvider = { [weak self] range, _ -> String? in
-                return self?.textView.textContentStorage.textStorage?.mutableString.substring(with: range)
+                return self?.textView.textContentStorage?.textStorage?.mutableString.substring(with: range)
             }
 
             provider = TreeSitterClient(codeLanguage: language, textProvider: textProvider)

--- a/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+ContentStorage.swift
+++ b/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+ContentStorage.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  STTextView+ContentStorage.swift
 //  
 //
 //  Created by Khan Winter on 4/24/23.

--- a/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+ContentStorage.swift
+++ b/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+ContentStorage.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Khan Winter on 4/24/23.
+//
+
+import Foundation
+import AppKit
+import STTextView
+
+extension STTextView {
+    /// Convenience that unwraps `textContentManager` as an `NSTextContentStorage` subclass.
+    var textContentStorage: NSTextContentStorage? {
+        return textContentManager as? NSTextContentStorage
+    }
+}

--- a/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+TextInterface.swift
+++ b/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+TextInterface.swift
@@ -16,6 +16,9 @@ extension STTextView: TextInterface {
             return self.selectedRange()
         }
         set {
+            guard let textContentStorage = textContentStorage else {
+                return
+            }
             if let textRange = NSTextRange(newValue, provider: textContentStorage) {
                 self.setSelectedRange(textRange)
             }
@@ -23,11 +26,11 @@ extension STTextView: TextInterface {
     }
 
     public var length: Int {
-        textContentStorage.length
+        textContentStorage?.length ?? 0
     }
 
     public func substring(from range: NSRange) -> String? {
-        return textContentStorage.substring(from: range)
+        return textContentStorage?.substring(from: range)
     }
 
     public func applyMutation(_ mutation: TextStory.TextMutation) {
@@ -39,10 +42,10 @@ extension STTextView: TextInterface {
             })
         }
 
-        textContentStorage.performEditingTransaction {
-            textContentStorage.applyMutation(mutation)
+        textContentStorage?.performEditingTransaction {
+            textContentStorage?.applyMutation(mutation)
         }
 
-        didChangeText()
+        textDidChange(nil)
     }
 }

--- a/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+VisibleRange.swift
+++ b/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+VisibleRange.swift
@@ -12,6 +12,10 @@ import AppKit
 extension STTextView {
     /// A helper for calculating the visible range on the text view with some small vertical padding.
     var visibleTextRange: NSRange? {
+        guard let textContentStorage = textContentStorage else {
+            return nil
+        }
+
         // This helper finds the visible rect of the text using the enclosing scroll view, then finds the nearest
         // `NSTextElement`s to those points and uses those elements to create the returned range.
 

--- a/Sources/CodeEditTextView/Filters/STTextViewController+TextFormation.swift
+++ b/Sources/CodeEditTextView/Filters/STTextViewController+TextFormation.swift
@@ -96,13 +96,14 @@ extension STTextViewController {
     public func textView(_ textView: STTextView,
                          shouldChangeTextIn affectedCharRange: NSTextRange,
                          replacementString: String?) -> Bool {
-        guard let range = affectedCharRange.nsRange(using: textView.textContentStorage) else {
+        guard let textContentStorage = textView.textContentStorage,
+              let range = affectedCharRange.nsRange(using: textContentStorage) else {
             return true
         }
 
         let mutation = TextMutation(string: replacementString ?? "",
                                     range: range,
-                                    limit: textView.textContentStorage.length)
+                                    limit: textView.textContentStorage?.length ?? 0)
 
         textView.undoManager?.beginUndoGrouping()
 

--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -32,7 +32,7 @@ class Highlighter: NSObject {
 
     /// The range of the entire document
     private var entireTextRange: Range<Int> {
-        return 0..<(textView.textContentStorage.textStorage?.length ?? 0)
+        return 0..<(textView.textContentStorage?.textStorage?.length ?? 0)
     }
 
     /// The set of visible indexes in tht text view
@@ -82,12 +82,12 @@ class Highlighter: NSObject {
 
         highlightProvider?.setLanguage(codeLanguage: language)
 
-        guard textView.textContentStorage.textStorage != nil else {
+        guard textView.textContentStorage?.textStorage != nil else {
             assertionFailure("Text view does not have a textStorage")
             return
         }
 
-        textView.textContentStorage.textStorage?.delegate = self
+        textView.textContentStorage?.textStorage?.delegate = self
         highlightProvider?.setUp(textView: textView)
 
         if let scrollView = textView.enclosingScrollView {
@@ -188,7 +188,7 @@ private extension Highlighter {
             }
 
             // Loop through each highlight and modify the textStorage accordingly.
-            textView.textContentStorage.textStorage?.beginEditing()
+            textView.textContentStorage?.textStorage?.beginEditing()
 
             // Create a set of indexes that were not highlighted.
             var ignoredIndexes = IndexSet(integersIn: rangeToHighlight)
@@ -200,7 +200,7 @@ private extension Highlighter {
 //                                                                  for: NSTextRange(highlight.range,
 //                                                                       provider: textView.textContentStorage)!)
                 // Temp solution (until Apple fixes above)
-                textView.textContentStorage.textStorage?.setAttributes(
+                textView.textContentStorage?.textStorage?.setAttributes(
                     attributeProvider.attributesFor(highlight.capture),
                     range: highlight.range
                 )
@@ -213,13 +213,13 @@ private extension Highlighter {
             // This fixes the case where characters are changed to have a non-text color, and then are skipped when
             // they need to be changed back.
             for ignoredRange in ignoredIndexes.rangeView {
-                textView.textContentStorage.textStorage?.setAttributes(
+                textView.textContentStorage?.textStorage?.setAttributes(
                     attributeProvider.attributesFor(nil),
                     range: NSRange(ignoredRange)
                 )
             }
 
-            textView.textContentStorage.textStorage?.endEditing()
+            textView.textContentStorage?.textStorage?.endEditing()
 
             // After applying edits to the text storage we need to invalidate the layout
             // of the highlighted text.

--- a/Sources/CodeEditTextView/Highlighting/HighlighterTextView.swift
+++ b/Sources/CodeEditTextView/Highlighting/HighlighterTextView.swift
@@ -21,10 +21,10 @@ public protocol HighlighterTextView {
 extension STTextView: HighlighterTextView {
     public var documentRange: NSRange {
         return NSRange(location: 0,
-                       length: textContentStorage.textStorage?.length ?? 0)
+                       length: textContentStorage?.textStorage?.length ?? 0)
     }
 
     public func stringForRange(_ nsRange: NSRange) -> String? {
-        return textContentStorage.textStorage?.mutableString.substring(with: nsRange)
+        return textContentStorage?.textStorage?.mutableString.substring(with: nsRange)
     }
 }

--- a/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
+++ b/Tests/CodeEditTextViewTests/STTextViewControllerTests.swift
@@ -162,37 +162,37 @@ final class STTextViewControllerTests: XCTestCase {
     func test_indentBehavior() {
         // Insert 1 space
         controller.indentOption = .spaces(count: 1)
-        controller.textView.string = ""
+        controller.textView.textContentStorage?.textStorage?.replaceCharacters(in: NSRange(location: 0, length: controller.textView.textContentStorage?.textStorage?.length ?? 0), with: "")
         controller.insertTab(nil)
         XCTAssertEqual(controller.textView.string, " ")
 
         // Insert 2 spaces
         controller.indentOption = .spaces(count: 2)
-        controller.textView.string = ""
+        controller.textView.textContentStorage?.textStorage?.replaceCharacters(in: NSRange(location: 0, length: controller.textView.textContentStorage?.textStorage?.length ?? 0), with: "")
         controller.textView.insertText("\t", replacementRange: .zero)
         XCTAssertEqual(controller.textView.string, "  ")
 
         // Insert 3 spaces
         controller.indentOption = .spaces(count: 3)
-        controller.textView.string = ""
+        controller.textView.textContentStorage?.textStorage?.replaceCharacters(in: NSRange(location: 0, length: controller.textView.textContentStorage?.textStorage?.length ?? 0), with: "")
         controller.textView.insertText("\t", replacementRange: .zero)
         XCTAssertEqual(controller.textView.string, "   ")
 
         // Insert 4 spaces
         controller.indentOption = .spaces(count: 4)
-        controller.textView.string = ""
+        controller.textView.textContentStorage?.textStorage?.replaceCharacters(in: NSRange(location: 0, length: controller.textView.textContentStorage?.textStorage?.length ?? 0), with: "")
         controller.textView.insertText("\t", replacementRange: .zero)
         XCTAssertEqual(controller.textView.string, "    ")
 
         // Insert tab
         controller.indentOption = .tab
-        controller.textView.string = ""
+        controller.textView.textContentStorage?.textStorage?.replaceCharacters(in: NSRange(location: 0, length: controller.textView.textContentStorage?.textStorage?.length ?? 0), with: "")
         controller.textView.insertText("\t", replacementRange: .zero)
         XCTAssertEqual(controller.textView.string, "\t")
 
         // Insert lots of spaces
         controller.indentOption = .spaces(count: 1000)
-        controller.textView.string = ""
+        controller.textView.textContentStorage?.textStorage?.replaceCharacters(in: NSRange(location: 0, length: controller.textView.textContentStorage?.textStorage?.length ?? 0), with: "")
         controller.textView.insertText("\t", replacementRange: .zero)
         XCTAssertEqual(controller.textView.string, String(repeating: " ", count: 1000))
     }


### PR DESCRIPTION
### Description

Updates STTextView to 0.5.3, accounting for a couple API changes & depreciations.

Known issues:
- [Editing with multiple cursors loses focus of all but the top-left cursor after applying the edit.](https://github.com/krzyzanowskim/STTextView/discussions/17)

Also includes a tiny fix for a runtime error when publishing cursor position, and a fix for a rare crash to do with string indexes. (`STTextViewController+Cursor.swift`).

### Related Issues

> N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Copy-paste attributed text

https://user-images.githubusercontent.com/35942988/234060270-82170964-c1b1-4dbf-bea2-3d6108857b3f.mov

Multiple cursors (control-shift click)

https://user-images.githubusercontent.com/35942988/234060289-f564f8be-ae57-482d-9037-9fd144591a1c.mov
