### PR TITLE
Improved vertical line alignment

### DIFF
--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -330,7 +330,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
     /// Calculated baseline offset depending on `lineHeight`.
     internal var baselineOffset: Double {
-        ((self.lineHeight) - font.lineHeight) / 2
+        ((self.lineHeight) - font.lineHeight) / 2 + 2
     }
 
     // MARK: Selectors


### PR DESCRIPTION
### Description

Currently the line is misaligned, this change makes line content centered aligned vertically. 

**Note:** In order to fix this, I am adding `2` to the baseline offset. I cannot find why it is off by `2` in the first place. I'd like to not use a magic number, but unless another solution can be found, this will do for the time being. I played with font size and line height values and it remains centered, so it is truly off by `2`.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before
<img width="224" alt="image" src="https://user-images.githubusercontent.com/806104/234171466-166ef338-dc0a-4aea-a0ee-56d399dfcee1.png">

After
<img width="223" alt="image" src="https://user-images.githubusercontent.com/806104/234171309-4269b1d9-4e5a-437d-99ea-170d6c3cbcef.png">
