### PR TITLE
Line highlight improvements when not using theme background

### DIFF
--- a/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Highlighter.swift
@@ -39,4 +39,17 @@ extension STTextViewController {
             highlighter?.setHighlightProvider(provider)
         }
     }
+
+    /// Gets all attributes for the given capture including the line height, background color, and text color.
+    /// - Parameter capture: The capture to use for syntax highlighting.
+    /// - Returns: All attributes to be applied.
+    public func attributesFor(_ capture: CaptureName?) -> [NSAttributedString.Key: Any] {
+        return [
+            .font: font,
+            .foregroundColor: theme.colorFor(capture),
+            .baselineOffset: baselineOffset,
+            .paragraphStyle: paragraphStyle,
+            .kern: kern
+        ]
+    }
 }

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -89,7 +89,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     }
 
     /// The kern to use for characters. Defaults to `0.0` and is updated when `letterSpacing` is set.
-    private var kern: CGFloat = 0.0
+    internal var kern: CGFloat = 0.0
 
     private var fontCharWidth: CGFloat {
         (" " as NSString).size(withAttributes: [.font: font]).width
@@ -274,7 +274,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
     // MARK: UI
 
     /// A default `NSParagraphStyle` with a set `lineHeight`
-    private lazy var paragraphStyle: NSMutableParagraphStyle = generateParagraphStyle()
+    internal lazy var paragraphStyle: NSMutableParagraphStyle = generateParagraphStyle()
 
     private func generateParagraphStyle() -> NSMutableParagraphStyle {
         // swiftlint:disable:next force_cast
@@ -333,19 +333,6 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
 
         highlighter?.invalidate()
         updateTextContainerWidthIfNeeded()
-    }
-
-    /// Gets all attributes for the given capture including the line height, background color, and text color.
-    /// - Parameter capture: The capture to use for syntax highlighting.
-    /// - Returns: All attributes to be applied.
-    public func attributesFor(_ capture: CaptureName?) -> [NSAttributedString.Key: Any] {
-        return [
-            .font: font,
-            .foregroundColor: theme.colorFor(capture),
-            .baselineOffset: baselineOffset,
-            .paragraphStyle: paragraphStyle,
-            .kern: kern
-        ]
     }
 
     /// Calculated line height depending on ``STTextViewController/lineHeightMultiple``


### PR DESCRIPTION
### Description

Not using theme highlight color when not using theme background. Instead, we are using system colors to highlight the current line.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

When using the theme background...

<img width="628" alt="image" src="https://user-images.githubusercontent.com/806104/234382400-afa7ce2f-4e81-47e1-a022-5a4cf24d8db1.png">

When not using the theme background...

Before
<img width="626" alt="image" src="https://user-images.githubusercontent.com/806104/234380570-5b3aac7e-4baa-4aa3-8d09-b2d4e4113b7c.png">

After
<img width="634" alt="image" src="https://user-images.githubusercontent.com/806104/234380524-eb4167f4-750c-4f3b-b4d4-5467738d3cdc.png">