### PR TITLE
Update Visible Set When Invalidated

### DIFF
--- a/Sources/CodeEditTextView/Highlighting/Highlighter.swift
+++ b/Sources/CodeEditTextView/Highlighting/Highlighter.swift
@@ -107,6 +107,7 @@ class Highlighter: NSObject {
 
     /// Invalidates all text in the textview. Useful for updating themes.
     public func invalidate() {
+        updateVisibleSet()
         invalidate(range: NSRange(entireTextRange))
     }
 
@@ -245,11 +246,15 @@ private extension Highlighter {
 // MARK: - Visible Content Updates
 
 private extension Highlighter {
-    /// Updates the view to highlight newly visible text when the textview is scrolled or bounds change.
-    @objc func visibleTextChanged(_ notification: Notification) {
+    private func updateVisibleSet() {
         if let newVisibleRange = textView.visibleTextRange {
             visibleSet = IndexSet(integersIn: newVisibleRange)
         }
+    }
+
+    /// Updates the view to highlight newly visible text when the textview is scrolled or bounds change.
+    @objc func visibleTextChanged(_ notification: Notification) {
+        updateVisibleSet()
 
         // Any indices that are both *not* valid and in the visible text range should be invalidated
         let newlyInvalidSet = visibleSet.subtracting(validSet)


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds a method to update the visible set and adds a call to that method when invalidating the entire document to ensure any newly visible text is correctly re-highlighted.

### Related Issues

- Closes #190 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/05347932-ed0b-4a72-ace4-551300e5e7aa


