### PR TITLE
Bump STTextView to 0.6.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/krzyzanowskim/STTextView.git",
-            exact: "0.5.3"
+            exact: "0.6.7"
         ),
         .package(
             url: "https://github.com/CodeEditApp/CodeEditLanguages.git",

--- a/Sources/CodeEditTextView/CEScrollView.swift
+++ b/Sources/CodeEditTextView/CEScrollView.swift
@@ -26,7 +26,7 @@ class CEScrollView: NSScrollView {
             let endLocation = textView.textLayoutManager.documentRange.endLocation
             let range = NSTextRange(location: endLocation)
             _ = textView.becomeFirstResponder()
-            textView.setSelectedRange(range)
+            textView.setSelectedTextRange(range)
         }
 
         super.mouseDown(with: event)

--- a/Sources/CodeEditTextView/Controller/STTextViewController+Cursor.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Cursor.swift
@@ -22,7 +22,7 @@ extension STTextViewController {
                 let range = NSRange(string.startIndex..<string.endIndex, in: string)
                 if let newRange = NSTextRange(range, provider: provider) {
                     _ = self.textView.becomeFirstResponder()
-                    self.textView.setSelectedRange(newRange)
+                    self.textView.setSelectedTextRange(newRange)
                     return
                 }
             }
@@ -37,7 +37,7 @@ extension STTextViewController {
                         min(lineRange.upperBound, string.index(lineRange.lowerBound, offsetBy: column - 1))
                     )
                     if let newRange = NSTextRange(NSRange(index..<index, in: string), provider: provider) {
-                        self.textView.setSelectedRange(newRange)
+                        self.textView.setSelectedTextRange(newRange)
                     }
                     done = true
                 } else {

--- a/Sources/CodeEditTextView/Controller/STTextViewController+Lifecycle.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController+Lifecycle.swift
@@ -29,7 +29,7 @@ extension STTextViewController {
         scrollView.rulersVisible = true
 
         textView.typingAttributes = attributesFor(nil)
-        textView.defaultParagraphStyle = self.paragraphStyle
+        textView.typingAttributes[.paragraphStyle] = self.paragraphStyle
         textView.font = self.font
         textView.insertionPointWidth = 1.0
         textView.backgroundColor = .clear

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -197,7 +197,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
         textView.highlightSelectedLine = isEditable
         textView.typingAttributes = attributesFor(nil)
         paragraphStyle = generateParagraphStyle()
-        textView.defaultParagraphStyle = paragraphStyle
+        textView.typingAttributes[.paragraphStyle] = paragraphStyle
 
         rulerView.selectedLineHighlightColor = useThemeBackground ? theme.lineHighlight : systemAppearance == .darkAqua
             ? NSColor.quaternaryLabelColor

--- a/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+TextInterface.swift
+++ b/Sources/CodeEditTextView/Extensions/STTextView+/STTextView+TextInterface.swift
@@ -20,7 +20,7 @@ extension STTextView: TextInterface {
                 return
             }
             if let textRange = NSTextRange(newValue, provider: textContentStorage) {
-                self.setSelectedRange(textRange)
+                self.setSelectedTextRange(textRange)
             }
         }
     }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Updates STTextView to the latest version. We skipped a few versions that would not compile for tests.

### Related Issues

* closes #137 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

The only visual change is that wrapped lines now highlight the entire line instead of just the selected line (#137).

Old:
<img width="478" alt="5 3" src="https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/e97e951a-1b00-4597-af85-4510479092d2">

New:
<img width="478" alt="6 7" src="https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/dc8a8b66-4ac9-4fb8-80b7-cf90e86901eb">
