### PR TITLE
Update `tree-sitter` State Correctly On Language Change

### DIFF
--- a/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
+++ b/Sources/CodeEditTextView/TreeSitter/TreeSitterClient.swift
@@ -98,11 +98,7 @@ public final class TreeSitterClient: HighlightProviding {
         self.readBlock = textView.createReadBlock()
         queuedEdits.append {
             self.stateLock.lock()
-            if self.state == nil {
-                self.state = TreeSitterState(codeLanguage: codeLanguage, textView: textView)
-            } else {
-                self.state?.setLanguage(codeLanguage)
-            }
+            self.state = TreeSitterState(codeLanguage: codeLanguage, textView: textView)
             self.stateLock.unlock()
         }
         beginTasksIfNeeded()


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Makes the tree-sitter state update correctly when the language is changed. Previously on a language change the document wouldn't be re-parsed, resulting in all highlights returning nothing. Now the tree is re-parsed at the same time the new language is loaded.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* N/A, bug found while implementing language changing UI in CE.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A
