### PR TITLE
Set default ruler width

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
       "state" : {
-        "revision" : "016b0e8df9603122202aef1f17cdc7fb2b51e1d0",
-        "version" : "0.1.14"
+        "revision" : "aa7d922b2aa783ae6f2a1a2cb7010ae62b700e17",
+        "version" : "0.1.16"
       }
     },
     {
@@ -21,10 +21,10 @@
     {
       "identity" : "sttextview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/STTextView",
+      "location" : "https://github.com/krzyzanowskim/STTextView.git",
       "state" : {
-        "revision" : "6c6243ae790247368aea258e4fb3642523759bec",
-        "version" : "0.5.3"
+        "branch" : "897c5ff",
+        "revision" : "897c5ffe3c6b35664ab085d43238b3a95e79440d"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/TextFormation",
       "state" : {
-        "revision" : "78d0911ef1827957c836f312212cc111b9232046",
-        "version" : "0.6.7"
+        "revision" : "158a603054ed5176f18d7c08ba355c0e05cb0586",
+        "version" : "0.7.0"
       }
     },
     {

--- a/Sources/CodeEditTextView/Controller/STTextViewController.swift
+++ b/Sources/CodeEditTextView/Controller/STTextViewController.swift
@@ -207,9 +207,15 @@ public class STTextViewController: NSViewController, STTextViewDelegate, ThemeAt
             : NSColor.selectedTextBackgroundColor.withSystemEffect(.disabled)
         rulerView.baselineOffset = baselineOffset
         rulerView.highlightSelectedLine = isEditable
-        rulerView.rulerInsets = STRulerInsets(leading: rulerFont.pointSize * 1.6, trailing: 8)
+        rulerView.rulerInsets = STRulerInsets(leading: 12, trailing: 8)
         rulerView.font = rulerFont
         rulerView.backgroundColor = theme.background
+        rulerView.ruleThickness = max(
+            NSString(string: "1000").size(withAttributes: [.font: rulerFont]).width
+            + rulerView.rulerInsets.leading
+            + rulerView.rulerInsets.trailing,
+            rulerView.ruleThickness
+        )
         if self.isEditable == false {
             rulerView.selectedLineTextColor = nil
             rulerView.selectedLineHighlightColor = .clear


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Adds a minimum ruler width equal to 4 digits wide to reduce layout shift while scrolling.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* N/A, discussed a couple times in discord.

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Previous:
<img width="356" alt="Screenshot 2023-07-11 at 12 28 26 PM" src="https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/469044fa-189f-41d8-83ca-367f2244fe82">

Now:
<img width="321" alt="Screenshot 2023-07-11 at 12 27 51 PM" src="https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/547dcdda-f50e-4be6-a065-7fef5b6e7cd7">

