### PR TITLE
Fix First Responder Issues, Fix Custom Undo Manager

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
@@ -48,10 +48,6 @@ extension TextView {
                 self?.autoscroll(with: event)
             }
         }
-
-        if !self.isFirstResponder {
-            self.window?.makeFirstResponder(self)
-        }
     }
 
     override public func mouseUp(with event: NSEvent) {

--- a/Sources/CodeEditTextView/TextView/TextView+UndoRedo.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+UndoRedo.swift
@@ -10,6 +10,7 @@ import AppKit
 extension TextView {
     public func setUndoManager(_ newManager: CEUndoManager) {
         self._undoManager = newManager
+        self._undoManager?.setTextView(self)
     }
 
     override public var undoManager: UndoManager? {

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -383,7 +383,7 @@ public class TextView: NSView, NSTextContent {
         let hitView = super.hitTest(point)
 
         if let hitView, hitView != self,
-            (type(of: hitView) == CursorView.self || type(of: hitView) == LineFragmentView.self) {
+            type(of: hitView) == CursorView.self || type(of: hitView) == LineFragmentView.self {
             return self
         }
         return hitView

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -328,12 +328,12 @@ public class TextView: NSView, NSTextContent {
 
     /// Sent to the window's first responder when `NSWindow.makeKey()` occurs.
     @objc private func becomeKeyWindow() {
-        let _ = becomeFirstResponder()
+        _ = becomeFirstResponder()
     }
-    
+
     /// Sent to the window's first responder when `NSWindow.resignKey()` occurs.
     @objc private func resignKeyWindow() {
-        let _ = resignFirstResponder()
+        _ = resignFirstResponder()
     }
 
     open override var needsPanelToBecomeKey: Bool {
@@ -373,7 +373,7 @@ public class TextView: NSView, NSTextContent {
     }
 
     // MARK: - Hit test
-    
+
     /// Returns the responding view for a given point.
     /// - Parameter point: The point to find.
     /// - Returns: A view at the given point, if any.

--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -226,7 +226,7 @@ public class CEUndoManager {
     }
 
     // MARK: - Internal
-    
+
     /// Sets a new text view to use for mutation registration, undo/redo operations.
     /// - Parameter newTextView: The new text view.
     func setTextView(_ newTextView: TextView) {

--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -224,4 +224,12 @@ public class CEUndoManager {
     public func enable() {
         isDisabled = false
     }
+
+    // MARK: - Internal
+    
+    /// Sets a new text view to use for mutation registration, undo/redo operations.
+    /// - Parameter newTextView: The new text view.
+    func setTextView(_ newTextView: TextView) {
+        self.textView = newTextView
+    }
 }


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Fixes the case where clicking on the view would not give the text view first responder status. This was because `hitTest` was returning the cursor view or a line fragment view, each of which should be transparent to responder or `hitTest` checks. This is fixed by returning `self` from `TextView.hitTest` if a line fragment or cursor view would normally be returned.

Also fixes an issue with setting a custom `CEUndoManager` on the text view.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code