### PR TITLE
(fix: #9) Grayscale Selection When Not Focused

### DIFF
--- a/Sources/CodeEditTextView/Extensions/NSColor+Greyscale.swift
+++ b/Sources/CodeEditTextView/Extensions/NSColor+Greyscale.swift
@@ -1,0 +1,17 @@
+//
+//  NSColor+Greyscale.swift
+//  CodeEditTextView
+//
+//  Created by Khan Winter on 2/2/24.
+//
+
+import AppKit
+
+extension NSColor {
+    var grayscale: NSColor {
+        guard let color = self.usingColorSpace(.deviceRGB) else { return self }
+        // linear relative weights for grayscale: https://en.wikipedia.org/wiki/Grayscale
+        let gray = 0.299 * color.redComponent + 0.587 * color.greenComponent + 0.114 * color.blueComponent
+        return NSColor(white: gray, alpha: color.alphaComponent)
+    }
+}

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -269,7 +269,12 @@ public class TextSelectionManager: NSObject {
     ///   - context: The context to draw in.
     private func drawSelectedRange(in rect: NSRect, for textSelection: TextSelection, context: CGContext) {
         context.saveGState()
-        context.setFillColor(selectionBackgroundColor.cgColor)
+
+        let fillColor = (textView?.isFirstResponder ?? false)
+        ? selectionBackgroundColor.cgColor
+        : selectionBackgroundColor.grayscale.cgColor
+
+        context.setFillColor(fillColor)
 
         let fillRects = getFillRects(in: rect, for: textSelection)
 

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -314,12 +314,14 @@ public class TextView: NSView, NSTextContent {
     open override func becomeFirstResponder() -> Bool {
         isFirstResponder = true
         selectionManager.cursorTimer.resetTimer()
+        needsDisplay = true
         return super.becomeFirstResponder()
     }
 
     open override func resignFirstResponder() -> Bool {
         isFirstResponder = false
         selectionManager.removeCursors()
+        needsDisplay = true
         return super.resignFirstResponder()
     }
 


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Finishes #9, correctly changing selection highlights when the view is not focused. Similar to other MacOS controls, the selection color is simply made grayscale when not focused.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* closes #9

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/49c4f53c-2c38-4ca0-b2c4-aa2d155e1f89

