### PR TITLE
Fix CRLF Line Ending Typesetting

### DIFF
--- a/Tests/CodeEditTextViewTests/TypesetterTests.swift
+++ b/Tests/CodeEditTextViewTests/TypesetterTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import CodeEditTextView
+
+// swiftlint:disable all
+
+class TypesetterTests: XCTestCase {
+    let limitedLineWidthDisplayData = TextLine.DisplayData(maxWidth: 150, lineHeightMultiplier: 1.0, estimatedLineHeight: 20.0)
+    let unlimitedLineWidthDisplayData = TextLine.DisplayData(maxWidth: .infinity, lineHeightMultiplier: 1.0, estimatedLineHeight: 20.0)
+
+    func test_LineFeedBreak() {
+        let typesetter = Typesetter()
+        typesetter.typeset(
+            NSAttributedString(string: "testline\n"),
+            displayData: unlimitedLineWidthDisplayData,
+            breakStrategy: .word,
+            markedRanges: nil
+        )
+
+        XCTAssertEqual(typesetter.lineFragments.count, 1, "Typesetter typeset incorrect number of lines.")
+
+        typesetter.typeset(
+            NSAttributedString(string: "testline\n"),
+            displayData: unlimitedLineWidthDisplayData,
+            breakStrategy: .character,
+            markedRanges: nil
+        )
+
+        XCTAssertEqual(typesetter.lineFragments.count, 1, "Typesetter typeset incorrect number of lines.")
+    }
+
+    func test_carriageReturnBreak() {
+        let typesetter = Typesetter()
+        typesetter.typeset(
+            NSAttributedString(string: "testline\r"),
+            displayData: unlimitedLineWidthDisplayData,
+            breakStrategy: .word,
+            markedRanges: nil
+        )
+
+        XCTAssertEqual(typesetter.lineFragments.count, 1, "Typesetter typeset incorrect number of lines.")
+
+        typesetter.typeset(
+            NSAttributedString(string: "testline\r"),
+            displayData: unlimitedLineWidthDisplayData,
+            breakStrategy: .character,
+            markedRanges: nil
+        )
+
+        XCTAssertEqual(typesetter.lineFragments.count, 1, "Typesetter typeset incorrect number of lines.")
+    }
+
+    func test_carriageReturnLineFeedBreak() {
+        let typesetter = Typesetter()
+        typesetter.typeset(
+            NSAttributedString(string: "testline\r\n"),
+            displayData: unlimitedLineWidthDisplayData,
+            breakStrategy: .word,
+            markedRanges: nil
+        )
+
+        XCTAssertEqual(typesetter.lineFragments.count, 1, "Typesetter typeset incorrect number of lines.")
+
+        typesetter.typeset(
+            NSAttributedString(string: "testline\r\n"),
+            displayData: unlimitedLineWidthDisplayData,
+            breakStrategy: .character,
+            markedRanges: nil
+        )
+
+        XCTAssertEqual(typesetter.lineFragments.count, 1, "Typesetter typeset incorrect number of lines.")
+    }
+}
+
+// swiftlint:enable all


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Fixes a bug that made lines ending with the carriage return line feed (`\r\n`) string be typeset incorrectly, adding an extra visible line when one did not exist.

Also adds a few simple tests to avoid regression.

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves the issue please specify (e.g. * closes #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

* N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
