### PR TITLE
Optionally Use System Cursor

### DIFF
--- a/Sources/CodeEditTextView/Extensions/GC+ApproximateEqual.swift
+++ b/Sources/CodeEditTextView/Extensions/GC+ApproximateEqual.swift
@@ -1,0 +1,29 @@
+//
+//  GC+ApproximateEqual.swift
+//  CodeEditTextView
+//
+//  Created by Khan Winter on 2/16/24.
+//
+
+import Foundation
+
+extension CGFloat {
+    func approxEqual(_ other: CGFloat, tolerance: CGFloat = 0.5) -> Bool {
+        abs(self - other) <= tolerance
+    }
+}
+
+extension CGPoint {
+    func approxEqual(_ other: CGPoint, tolerance: CGFloat = 0.5) -> Bool {
+        return self.x.approxEqual(other.x, tolerance: tolerance)
+        && self.y.approxEqual(other.y, tolerance: tolerance)
+    }
+}
+
+extension CGRect {
+    func approxEqual(_ other: CGRect, tolerance: CGFloat = 0.5) -> Bool {
+        return self.origin.approxEqual(other.origin, tolerance: tolerance)
+        && self.width.approxEqual(other.width, tolerance: tolerance)
+        && self.height.approxEqual(other.height, tolerance: tolerance)
+    }
+}

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -180,7 +180,7 @@ public class TextSelectionManager: NSObject {
                     textSelection.view = nil
 
                     let cursorView: NSView
-                    
+
                     if useSystemCursor, #available(macOS 14.0, *) {
                         let systemCursorView = NSTextInsertionIndicator(frame: .zero)
                         cursorView = systemCursorView

--- a/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -20,7 +20,9 @@ extension TextView {
         NotificationCenter.default.post(name: Self.textWillChangeNotification, object: self)
         layoutManager.beginTransaction()
         textStorage.beginEditing()
-        // Can't insert an ssempty string into an empty range. One must be not empty
+        _undoManager?.beginGrouping()
+
+        // Can't insert an empty string into an empty range. One must be not empty
         for range in ranges.sorted(by: { $0.location > $1.location }) where
         (delegate?.textView(self, shouldReplaceContentsIn: range, with: string) ?? true)
         && (!range.isEmpty || !string.isEmpty) {
@@ -38,6 +40,8 @@ extension TextView {
 
             delegate?.textView(self, didReplaceContentsIn: range, with: string)
         }
+
+        _undoManager?.endGrouping()
         layoutManager.endTransaction()
         textStorage.endEditing()
         selectionManager.notifyAfterEdit()

--- a/Sources/CodeEditTextView/TextView/TextView+Setup.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Setup.swift
@@ -26,4 +26,35 @@ extension TextView {
             delegate: self
         )
     }
+
+    func setUpScrollListeners(scrollView: NSScrollView) {
+        NotificationCenter.default.removeObserver(self, name: NSScrollView.willStartLiveScrollNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSScrollView.didEndLiveScrollNotification, object: nil)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(scrollViewWillStartScroll),
+            name: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(scrollViewDidEndScroll),
+            name: NSScrollView.didEndLiveScrollNotification,
+            object: scrollView
+        )
+    }
+
+    @objc func scrollViewWillStartScroll() {
+        if #available(macOS 14.0, *) {
+            inputContext?.textInputClientWillStartScrollingOrZooming()
+        }
+    }
+
+    @objc func scrollViewDidEndScroll() {
+        if #available(macOS 14.0, *) {
+            inputContext?.textInputClientDidEndScrollingOrZooming()
+        }
+    }
 }

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -241,6 +241,7 @@ public class TextView: NSView, NSTextContent {
     ///   - isEditable: Determines if the view is editable.
     ///   - isSelectable: Determines if the view is selectable.
     ///   - letterSpacing: Sets the letter spacing on the view.
+    ///   - useSystemCursor: Set to true to use the system cursor. Only available in macOS >= 14.
     ///   - delegate: The text view's delegate.
     public init(
         string: String,
@@ -251,6 +252,7 @@ public class TextView: NSView, NSTextContent {
         isEditable: Bool,
         isSelectable: Bool,
         letterSpacing: Double,
+        useSystemCursor: Bool = false,
         delegate: TextViewDelegate
     ) {
         self.textStorage = NSTextStorage(string: string)
@@ -280,6 +282,7 @@ public class TextView: NSView, NSTextContent {
         layoutManager = setUpLayoutManager(lineHeightMultiplier: lineHeightMultiplier, wrapLines: wrapLines)
         storageDelegate.addDelegate(layoutManager)
         selectionManager = setUpSelectionManager()
+        selectionManager.useSystemCursor = useSystemCursor
 
         _undoManager = CEUndoManager(textView: self)
 
@@ -384,6 +387,14 @@ public class TextView: NSView, NSTextContent {
     override public func viewWillMove(toWindow newWindow: NSWindow?) {
         super.viewWillMove(toWindow: newWindow)
         layoutManager.layoutLines()
+    }
+
+    override public func viewWillMove(toSuperview newSuperview: NSView?) {
+        guard let scrollView = enclosingScrollView else {
+            return
+        }
+
+        setUpScrollListeners(scrollView: scrollView)
     }
 
     override public func viewDidEndLiveResize() {

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -177,7 +177,7 @@ public class TextView: NSView, NSTextContent {
             layoutManager.lineBreakStrategy = newValue
         }
     }
-    
+
     /// Determines if the text view uses the macOS system cursor or a ``CursorView`` for cursors.
     ///
     /// - Important: Only available after macOS 14.

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -177,6 +177,22 @@ public class TextView: NSView, NSTextContent {
             layoutManager.lineBreakStrategy = newValue
         }
     }
+    
+    /// Determines if the text view uses the macOS system cursor or a ``CursorView`` for cursors.
+    ///
+    /// - Important: Only available after macOS 14.
+    public var useSystemCursor: Bool {
+        get {
+            selectionManager?.useSystemCursor ?? false
+        }
+        set {
+            guard #available(macOS 14, *) else {
+                logger.warning("useSystemCursor only available after macOS 14.")
+                return
+            }
+            selectionManager?.useSystemCursor = newValue
+        }
+    }
 
     open var contentType: NSTextContentType?
 
@@ -203,7 +219,7 @@ public class TextView: NSView, NSTextContent {
         (" " as NSString).size(withAttributes: [.font: font]).width
     }
 
-    var _undoManager: CEUndoManager?
+    internal(set) public var _undoManager: CEUndoManager?
     @objc dynamic open var allowsUndo: Bool
 
     var scrollView: NSScrollView? {


### PR DESCRIPTION
### Description

Adds the ability to use the system cursor if available and enabled using a `useSystemCursor` variable on either `TextView` or `TextSelectionManager`.

### Related Issues

*  closes #5

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Example usage in CodeEditSourceEditor:

https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/5b5adeee-dd80-4f92-92d0-121be18ab6ae
