### PR TITLE
General Performance Improvements

### DIFF
--- a/Sources/CodeEditTextView/Cursors/CursorView.swift
+++ b/Sources/CodeEditTextView/Cursors/CursorView.swift
@@ -25,6 +25,8 @@ open class CursorView: NSView {
         true
     }
 
+    override open func hitTest(_ point: NSPoint) -> NSView? { nil }
+
     /// Create a cursor view.
     /// - Parameters:
     ///   - blinkDuration: The duration to blink, leave as nil to never blink.

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
@@ -54,6 +54,17 @@ public class TextLayoutManager: NSObject {
         }
     }
 
+    /// The amount of extra vertical padding used to lay out lines in before they come into view.
+    ///
+    /// This solves a small problem with layout performance, if you're seeing layout lagging behind while scrolling,
+    /// adjusting this value higher may help fix that.
+    /// Defaults to `350`.
+    public var verticalLayoutPadding: CGFloat = 350 {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+
     // MARK: - Internal
 
     weak var textStorage: NSTextStorage?
@@ -234,8 +245,8 @@ public class TextLayoutManager: NSObject {
     func layoutLines() { // swiftlint:disable:this function_body_length
         guard let visibleRect = delegate?.visibleRect, !isInTransaction, let textStorage else { return }
         CATransaction.begin()
-        let minY = max(visibleRect.minY - 350, 0) // +-350px for a bit padding while laying out lines.
-        let maxY = max(visibleRect.maxY + 350, 0)
+        let minY = max(visibleRect.minY - verticalLayoutPadding, 0)
+        let maxY = max(visibleRect.maxY + verticalLayoutPadding, 0)
         let originalHeight = lineStorage.height
         var usedFragmentIDs = Set<UUID>()
         var forceLayout: Bool = needsLayout

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
@@ -234,18 +234,14 @@ public class TextLayoutManager: NSObject {
     func layoutLines() { // swiftlint:disable:this function_body_length
         guard let visibleRect = delegate?.visibleRect, !isInTransaction, let textStorage else { return }
         CATransaction.begin()
-        let minY = max(visibleRect.minY, 0)
-        let maxY = max(visibleRect.maxY, 0)
+        let minY = max(visibleRect.minY - 350, 0) // +-350px for a bit padding while laying out lines.
+        let maxY = max(visibleRect.maxY + 350, 0)
         let originalHeight = lineStorage.height
         var usedFragmentIDs = Set<UUID>()
         var forceLayout: Bool = needsLayout
         var newVisibleLines: Set<TextLine.ID> = []
         var yContentAdjustment: CGFloat = 0
         var maxFoundLineWidth = maxLineWidth
-
-        var info = mach_timebase_info()
-        guard mach_timebase_info(&info) == KERN_SUCCESS else { return }
-        let start = mach_absolute_time()
 
         // Layout all lines
         for linePosition in lineStorage.linesStartingAt(minY, until: maxY) {

--- a/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
+++ b/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
@@ -19,6 +19,8 @@ final class LineFragmentView: NSView {
         false
     }
 
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
     /// Prepare the view for reuse, clears the line fragment reference.
     override func prepareForReuse() {
         super.prepareForReuse()

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -381,15 +381,11 @@ public class TextView: NSView, NSTextContent {
     /// - Parameter point: The point to find.
     /// - Returns: A view at the given point, if any.
     override public func hitTest(_ point: NSPoint) -> NSView? {
-        // For our purposes, cursor and line fragment views should be transparent from the point of view of
-        // all other views. So, if the normal hitTest returns one of them, we return `self` instead.
-        let hitView = super.hitTest(point)
-
-        if let hitView, hitView != self,
-            type(of: hitView) == CursorView.self || type(of: hitView) == LineFragmentView.self {
+        if visibleRect.contains(point) {
             return self
+        } else {
+            return super.hitTest(point)
         }
-        return hitView
     }
 
     // MARK: - Key Down

--- a/Sources/CodeEditTextView/Utils/ViewReuseQueue.swift
+++ b/Sources/CodeEditTextView/Utils/ViewReuseQueue.swift
@@ -52,7 +52,7 @@ public class ViewReuseQueue<View: NSView, Key: Hashable> {
     /// Enqueues all views not in the given set.
     /// - Parameter outsideSet: The keys who's views should not be enqueued for reuse.
     public func enqueueViews(notInSet keys: Set<Key>) {
-        // Get all keys that are in "use" but not in the given set.
+        // Get all keys that are currently in "use" but not in the given set, and enqueue them for reuse.
         for key in Set(usedViews.keys).subtracting(keys) {
             enqueueView(forKey: key)
         }


### PR DESCRIPTION
### Description

- Updates the `layoutManager.endTransaction` method to only force layout if determined to be necessary by the caller, dramatically reducing the number of times complete layout occurs.
- Cleans up the `hitTest` method on `TextView` to just return `self` if the hit is in the visible rect (was taking 100's of ms to perform before).
- Adds 350px of padding to the layout method in `TextLayoutManager`. This fixes a small visible bug where scrolling very fast would briefly lag behind on layout and lines would not be rendered immediately. With this change, the lag still occurs but it happens invisibly to the user.

For the last point, it was determined that the slowest part of the layout process is actually removing line fragment views from the hierarchy. Other methods were explored such as hiding views or setting their frame to 0 in place of removing them, but similar performance hits occurred.

### Related Issues

* N/S

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code