### PR TITLE
UndoManager Fixes

### DIFF
--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Invalidation.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Invalidation.swift
@@ -1,0 +1,34 @@
+//
+//  TextLayoutManager+Invalidation.swift
+//  CodeEditTextView
+//
+//  Created by Khan Winter on 2/24/24.
+//
+
+import Foundation
+
+extension TextLayoutManager {
+    /// Invalidates layout for the given rect.
+    /// - Parameter rect: The rect to invalidate.
+    public func invalidateLayoutForRect(_ rect: NSRect) {
+        for linePosition in lineStorage.linesStartingAt(rect.minY, until: rect.maxY) {
+            linePosition.data.setNeedsLayout()
+        }
+        layoutLines()
+    }
+
+    /// Invalidates layout for the given range of text.
+    /// - Parameter range: The range of text to invalidate.
+    public func invalidateLayoutForRange(_ range: NSRange) {
+        for linePosition in lineStorage.linesInRange(range) {
+            linePosition.data.setNeedsLayout()
+        }
+
+        layoutLines()
+    }
+
+    public func setNeedsLayout() {
+        needsLayout = true
+        visibleLineIds.removeAll(keepingCapacity: true)
+    }
+}

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Transaction.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Transaction.swift
@@ -30,8 +30,9 @@ extension TextLayoutManager {
             }
             layoutLines()
         } else if transactionCounter < 0 {
-            // swiftlint:disable:next line_length
-            assertionFailure("TextLayoutManager.endTransaction called without a matching TextLayoutManager.beginTransaction call")
+            assertionFailure(
+                "TextLayoutManager.endTransaction called without a matching TextLayoutManager.beginTransaction call"
+            )
         }
     }
 }

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Transaction.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Transaction.swift
@@ -1,0 +1,37 @@
+//
+//  TextLayoutManager+Transaction.swift
+//  CodeEditTextView
+//
+//  Created by Khan Winter on 2/24/24.
+//
+
+import Foundation
+
+extension TextLayoutManager {
+    /// Begins a transaction, preventing the layout manager from performing layout until the `endTransaction` is called.
+    /// Useful for grouping attribute modifications into one layout pass rather than laying out every update.
+    ///
+    /// You can nest transaction start/end calls, the layout manager will not cause layout until the last transaction
+    /// group is ended.
+    ///
+    /// Ensure there is a balanced number of begin/end calls. If there is a missing endTranscaction call, the layout
+    /// manager will never lay out text. If there is a end call without matching a start call an assertionFailure
+    /// will occur.
+    public func beginTransaction() {
+        transactionCounter += 1
+    }
+
+    /// Ends a transaction. When called, the layout manager will layout any necessary lines.
+    public func endTransaction(forceLayout: Bool = false) {
+        transactionCounter -= 1
+        if transactionCounter == 0 {
+            if forceLayout {
+                setNeedsLayout()
+            }
+            layoutLines()
+        } else if transactionCounter < 0 {
+            // swiftlint:disable:next line_length
+            assertionFailure("TextLayoutManager.endTransaction called without a matching TextLayoutManager.beginTransaction call")
+        }
+    }
+}

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
@@ -71,11 +71,11 @@ public class TextLayoutManager: NSObject {
     var lineStorage: TextLineStorage<TextLine> = TextLineStorage()
     var markedTextManager: MarkedTextManager = MarkedTextManager()
     private let viewReuseQueue: ViewReuseQueue<LineFragmentView, UUID> = ViewReuseQueue()
-    private var visibleLineIds: Set<TextLine.ID> = []
+    package var visibleLineIds: Set<TextLine.ID> = []
     /// Used to force a complete re-layout using `setNeedsLayout`
-    private var needsLayout: Bool = false
+    package var needsLayout: Bool = false
 
-    private var transactionCounter: Int = 0
+    package var transactionCounter: Int = 0
     public var isInTransaction: Bool {
         transactionCounter > 0
     }
@@ -185,59 +185,6 @@ public class TextLayoutManager: NSObject {
     /// The last known line height estimate. If  set to `nil`, will be recalculated the next time
     /// ``TextLayoutManager/estimateLineHeight()`` is called.
     private var _estimateLineHeight: CGFloat?
-
-    // MARK: - Invalidation
-
-    /// Invalidates layout for the given rect.
-    /// - Parameter rect: The rect to invalidate.
-    public func invalidateLayoutForRect(_ rect: NSRect) {
-        for linePosition in lineStorage.linesStartingAt(rect.minY, until: rect.maxY) {
-            linePosition.data.setNeedsLayout()
-        }
-        layoutLines()
-    }
-
-    /// Invalidates layout for the given range of text.
-    /// - Parameter range: The range of text to invalidate.
-    public func invalidateLayoutForRange(_ range: NSRange) {
-        for linePosition in lineStorage.linesInRange(range) {
-            linePosition.data.setNeedsLayout()
-        }
-
-        layoutLines()
-    }
-
-    public func setNeedsLayout() {
-        needsLayout = true
-        visibleLineIds.removeAll(keepingCapacity: true)
-    }
-
-    /// Begins a transaction, preventing the layout manager from performing layout until the `endTransaction` is called.
-    /// Useful for grouping attribute modifications into one layout pass rather than laying out every update.
-    ///
-    /// You can nest transaction start/end calls, the layout manager will not cause layout until the last transaction
-    /// group is ended.
-    ///
-    /// Ensure there is a balanced number of begin/end calls. If there is a missing endTranscaction call, the layout
-    /// manager will never lay out text. If there is a end call without matching a start call an assertionFailure
-    /// will occur.
-    public func beginTransaction() {
-        transactionCounter += 1
-    }
-
-    /// Ends a transaction. When called, the layout manager will layout any necessary lines.
-    public func endTransaction(forceLayout: Bool = false) {
-        transactionCounter -= 1
-        if transactionCounter == 0 {
-            if forceLayout {
-                setNeedsLayout()
-            }
-            layoutLines()
-        } else if transactionCounter < 0 {
-            // swiftlint:disable:next line_length
-            assertionFailure("TextLayoutManager.endTransaction called without a matching TextLayoutManager.beginTransaction call")
-        }
-    }
 
     // MARK: - Layout
 

--- a/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -21,12 +21,6 @@ extension TextView {
         layoutManager.beginTransaction()
         textStorage.beginEditing()
 
-        var shouldEndGrouping = false
-        if !(_undoManager?.isGrouping ?? false) {
-            _undoManager?.beginGrouping()
-            shouldEndGrouping = true
-        }
-
         // Can't insert an empty string into an empty range. One must be not empty
         for range in ranges.sorted(by: { $0.location > $1.location }) where
         (!range.isEmpty || !string.isEmpty) &&
@@ -44,10 +38,6 @@ extension TextView {
             selectionManager.didReplaceCharacters(in: range, replacementLength: (string as NSString).length)
 
             delegate?.textView(self, didReplaceContentsIn: range, with: string)
-        }
-
-        if shouldEndGrouping {
-            _undoManager?.endGrouping()
         }
 
         layoutManager.endTransaction()

--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -22,6 +22,8 @@ public class CEUndoManager {
     public class DelegatedUndoManager: UndoManager {
         weak var parent: CEUndoManager?
 
+        public override var isUndoing: Bool { parent?.isUndoing ?? false }
+        public override var isRedoing: Bool { parent?.isRedoing ?? false }
         public override var canUndo: Bool { parent?.canUndo ?? false }
         public override var canRedo: Bool { parent?.canRedo ?? false }
 
@@ -97,9 +99,11 @@ public class CEUndoManager {
         }
         isUndoing = true
         NotificationCenter.default.post(name: .NSUndoManagerWillUndoChange, object: self.manager)
+        textView.textStorage.beginEditing()
         for mutation in item.mutations.reversed() {
             textView.replaceCharacters(in: mutation.inverse.range, with: mutation.inverse.string)
         }
+        textView.textStorage.endEditing()
         NotificationCenter.default.post(name: .NSUndoManagerDidUndoChange, object: self.manager)
         redoStack.append(item)
         isUndoing = false
@@ -112,9 +116,11 @@ public class CEUndoManager {
         }
         isRedoing = true
         NotificationCenter.default.post(name: .NSUndoManagerWillRedoChange, object: self.manager)
+        textView.textStorage.beginEditing()
         for mutation in item.mutations {
             textView.replaceCharacters(in: mutation.mutation.range, with: mutation.mutation.string)
         }
+        textView.textStorage.endEditing()
         NotificationCenter.default.post(name: .NSUndoManagerDidRedoChange, object: self.manager)
         undoStack.append(item)
         isRedoing = false
@@ -188,6 +194,7 @@ public class CEUndoManager {
     ///   - lastMutation: The last mutation applied to the document.
     /// - Returns: Whether or not the given mutations can be grouped.
     private func shouldContinueGroup(_ mutation: Mutation, lastMutation: Mutation) -> Bool {
+        return false
         // If last mutation was delete & new is insert or vice versa, split group
         if (mutation.mutation.range.length > 0 && lastMutation.mutation.range.length == 0)
             || (mutation.mutation.range.length == 0 && lastMutation.mutation.range.length > 0) {

--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -194,7 +194,6 @@ public class CEUndoManager {
     ///   - lastMutation: The last mutation applied to the document.
     /// - Returns: Whether or not the given mutations can be grouped.
     private func shouldContinueGroup(_ mutation: Mutation, lastMutation: Mutation) -> Bool {
-        return false
         // If last mutation was delete & new is insert or vice versa, split group
         if (mutation.mutation.range.length > 0 && lastMutation.mutation.range.length == 0)
             || (mutation.mutation.range.length == 0 && lastMutation.mutation.range.length > 0) {
@@ -205,7 +204,7 @@ public class CEUndoManager {
             // Deleting
             return (
                 lastMutation.mutation.range.location == mutation.mutation.range.max
-                && mutation.inverse.string != "\n"
+                && LineEnding(line: lastMutation.inverse.string) == nil
             )
         } else {
             // Inserting
@@ -214,14 +213,14 @@ public class CEUndoManager {
             // If the last mutation was not whitespace, and the new one is, break the group.
             if lastMutation.mutation.string.count < 1024
                 && mutation.mutation.string.count < 1024
-                && !lastMutation.mutation.string.trimmingCharacters(in: .whitespaces).isEmpty
+                && !lastMutation.mutation.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 && mutation.mutation.string.trimmingCharacters(in: .whitespaces).isEmpty {
                 return false
             }
 
             return (
                 lastMutation.mutation.range.max + 1 == mutation.mutation.range.location
-                && mutation.mutation.string != "\n"
+                && LineEnding(line: mutation.mutation.string) == nil
             )
         }
     }


### PR DESCRIPTION
### Description

- Fixes incorrect use of grouping in `replaceCharacters`. Fixes an issue where every edit was grouped, disabling the ability to undo individual operations. Future work will need to be done to enable grouping undo operations for multi-cursor operations.
- Makes undo/redo text storage operations occur in a transaction. Makes those operations appear as a single coalesced edit when sent to text storage delegates.
- Fixes an issue where the undo manager would never group the sequence of `Newline + Whitespace` (eg when making a newline and then inserting a tab). Also fixes the grouping order when deleting lines, so undoing a deleted line behaves as expected.

### Related Issues

* [CodeEditSourceEditor \#239](https://github.com/CodeEditApp/CodeEditSourceEditor/pull/239) requires this update.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A