### PR TITLE
(fix: #32) Fix Deleting Selected Range

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+Delete.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Delete.swift
@@ -51,6 +51,7 @@ extension TextView {
     ) {
         /// Extend each selection by a distance specified by `destination`, then update both storage and the selection.
         for textSelection in selectionManager.textSelections {
+            guard textSelection.range.isEmpty else { continue }
             let extendedRange = selectionManager.rangeOfSelection(
                 from: textSelection.range.location,
                 direction: direction,


### PR DESCRIPTION
<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

Fixes deleting a selected range, before would extend the selection range when deleting no matter what. This fixes it to only extend the range if it's a cursor rather than a selected range.

### Related Issues

* closes #32 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/bde4bdc6-ddfa-4ee7-b68e-64030d2819d4

