### PR TITLE
Add Edited Ranges to Notification

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -43,7 +43,11 @@ extension TextView {
         layoutManager.endTransaction()
         textStorage.endEditing()
         selectionManager.notifyAfterEdit()
-        NotificationCenter.default.post(name: Self.textDidChangeNotification, object: self)
+        NotificationCenter.default.post(
+            name: Self.textDidChangeNotification,
+            object: self,
+            userInfo: [Self.textDidChangeRangeKey: ranges]
+        )
     }
 
     /// Replace the characters in a range with a new string.

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -48,11 +48,13 @@ public class TextView: NSView, NSTextContent {
         [.font: NSFont.systemFont(ofSize: 12), .foregroundColor: NSColor.textColor, .kern: 0.0]
     }
 
-    // swiftlint:disable:next line_length
-    public static let textDidChangeNotification: Notification.Name = .init(rawValue: "com.CodeEdit.TextView.TextDidChangeNotification")
+    /// The notification sent when text changes.
+    public static let textDidChangeNotification: Notification.Name = .init(rawValue: "com.CodeEdit.TextView.TextDidChangeNotification") // swiftlint:disable:this line_length
+    /// The key name for the array of `NSRange` sent in the `userInfo` of the ``textDidChangeNotification``.
+    public static let textDidChangeRangeKey: String = "Range"
 
-    // swiftlint:disable:next line_length
-    public static let textWillChangeNotification: Notification.Name = .init(rawValue: "com.CodeEdit.TextView.TextWillChangeNotification")
+    /// The notification sent before text changes
+    public static let textWillChangeNotification: Notification.Name = .init(rawValue: "com.CodeEdit.TextView.TextWillChangeNotification") // swiftlint:disable:this line_length
 
     // MARK: - Configuration
 
@@ -308,6 +310,7 @@ public class TextView: NSView, NSTextContent {
     /// Set a new text storage object for the view.
     /// - Parameter textStorage: The new text storage to use.
     public func setTextStorage(_ textStorage: NSTextStorage) {
+        self.textStorage?.delegate = nil
         self.textStorage = textStorage
 
         subviews.forEach { view in
@@ -321,9 +324,9 @@ public class TextView: NSView, NSTextContent {
         selectionManager.textStorage = textStorage
         selectionManager.setSelectedRanges(selectionManager.textSelections.map { $0.range })
 
+        textStorage.delegate = storageDelegate
         _undoManager?.clearStack()
 
-        textStorage.delegate = storageDelegate
         needsDisplay = true
         needsLayout = true
     }


### PR DESCRIPTION
### Description

Adds the edited ranges to the `userInfo` property for text changed notifications.

### Related Issues

First PR in a series to fix this bug in CE:
* [CodeEdit#1728](https://github.com/CodeEditApp/CodeEdit/issues/1728)

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code
