### PR TITLE
Fix Hidden At End Of Doc

### DIFF
--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -233,12 +233,15 @@ public class TextSelectionManager: NSObject {
     /// - Parameter range: The range the cursor is at.
     /// - Returns: The height the cursor should be to match the text at that location.
     fileprivate func heightForCursorAt(_ range: NSRange) -> CGFloat? {
-        let selectedLine = layoutManager?.textLineForOffset(range.location)
-        return selectedLine?
+        guard let selectedLine = layoutManager?.textLineForOffset(range.location) else {
+            return layoutManager?.estimateLineHeight()
+        }
+        return selectedLine
             .data
             .lineFragments
-            .getLine(atOffset: range.location - (selectedLine?.range.location ?? 0))?
+            .getLine(atOffset: range.location - (selectedLine.range.location))?
             .height
+        ?? layoutManager?.estimateLineHeight()
 
     }
 


### PR DESCRIPTION
### Description

Fixes an issue where the cursor would be invisible when placed at the end of the document.

This was caused by an internal function returning a height of `0` for the position at the very end of the document. It's been updated.

### Related Issues

* closes https://github.com/CodeEditApp/CodeEdit/issues/1755

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/0f2f078b-6f98-4219-805f-a9ed5975f575

