### PR TITLE
Fix Marked Text Input

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,6 @@
+excluded:
+  - .build
+
 disabled_rules:
   - todo
   - trailing_comma

--- a/Sources/CodeEditTextView/MarkedTextManager/MarkedTextManager.swift
+++ b/Sources/CodeEditTextView/MarkedTextManager/MarkedTextManager.swift
@@ -47,30 +47,21 @@ class MarkedTextManager {
     /// - Parameters:
     ///   - insertLength: The length of the string being inserted.
     ///   - textSelections: The current text selections.
-    func updateMarkedRanges(
-        insertLength: Int,
-        textSelections: [NSRange]
-    ) {
+    func updateMarkedRanges(insertLength: Int, textSelections: [NSRange]) {
         var cumulativeExistingDiff = 0
-        if markedRanges.isEmpty {
-            let lengthDiff = insertLength
-            var newRanges = [NSRange]()
-            for (idx, range) in textSelections.sorted(by: { $0.location < $1.location }).enumerated() {
-                let rangeOffset = (lengthDiff * idx) - cumulativeExistingDiff
-                newRanges.append(NSRange(location: range.location + rangeOffset, length: insertLength))
-                cumulativeExistingDiff += range.length
-            }
-            markedRanges = newRanges
-        } else if let firstRange = markedRanges.first {
-            let lengthDiff = insertLength - firstRange.length
-            var newRanges = [NSRange]()
-            for (idx, range) in markedRanges.sorted(by: { $0.location < $1.location }).enumerated() {
-                let rangeOffset = (lengthDiff * idx) - cumulativeExistingDiff
-                newRanges.append(NSRange(location: range.location + rangeOffset, length: insertLength))
-                cumulativeExistingDiff += range.length
-            }
-            markedRanges = newRanges
+        let lengthDiff = insertLength
+        var newRanges = [NSRange]()
+        let ranges: [NSRange] = if markedRanges.isEmpty {
+            textSelections.sorted(by: { $0.location < $1.location })
+        } else {
+            markedRanges.sorted(by: { $0.location < $1.location })
         }
+
+        for (idx, range) in ranges.enumerated() {
+            newRanges.append(NSRange(location: range.location + cumulativeExistingDiff, length: insertLength))
+            cumulativeExistingDiff += insertLength - range.length
+        }
+        markedRanges = newRanges
     }
 
     /// Finds any marked ranges for a line and returns them.

--- a/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
@@ -107,6 +107,7 @@ extension TextView: NSTextInputClient {
             insertLength: (insertString as NSString).length,
             textSelections: selectionCopies
         )
+
         // Reset the selected ranges to reflect the replaced text.
         selectionManager.setSelectedRanges(layoutManager.markedTextManager.markedRanges.map({
             NSRange(location: $0.max, length: 0)

--- a/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
@@ -80,13 +80,10 @@ extension TextView: NSTextInputClient {
 
     // MARK: - Marked Text
 
-    /// Replaces a specified range in the receiver’s text storage with the given string and sets the selection.
+    /// Sets up marked text for a marking session. See ``MarkedTextManager`` for more details.
     ///
-    /// If there is no marked text, the current selection is replaced. If there is no selection, the string is
-    /// inserted at the insertion point.
-    ///
-    /// When `string` is an `NSString` object, the receiver is expected to render the marked text with
-    /// distinguishing appearance (for example, `NSTextView` renders with `markedTextAttributes`).
+    /// Decides whether or not to insert/replace text. Then updates the current marked ranges and updates cursor
+    /// positions.
     ///
     /// - Parameters:
     ///   - string: The string to insert. Can be either an NSString or NSAttributedString instance.
@@ -96,13 +93,25 @@ extension TextView: NSTextInputClient {
         guard isEditable, let insertString = anyToString(string) else { return }
         // Needs to insert text, but not notify the undo manager.
         _undoManager?.disable()
+        let shouldInsert = layoutManager.markedTextManager.markedRanges.isEmpty
+
+        // Copy the text selections *before* we modify them.
+        let selectionCopies = selectionManager.textSelections.map(\.range)
+
+        if shouldInsert {
+            _insertText(insertString: insertString, replacementRange: replacementRange)
+        } else {
+            replaceCharacters(in: layoutManager.markedTextManager.markedRanges, with: insertString)
+        }
         layoutManager.markedTextManager.updateMarkedRanges(
             insertLength: (insertString as NSString).length,
-            replacementRange: replacementRange,
-            selectedRange: selectedRange,
-            textSelections: selectionManager.textSelections
+            textSelections: selectionCopies
         )
-        _insertText(insertString: insertString, replacementRange: replacementRange)
+        // Reset the selected ranges to reflect the replaced text.
+        selectionManager.setSelectedRanges(layoutManager.markedTextManager.markedRanges.map({
+            NSRange(location: $0.max, length: 0)
+        }))
+
         _undoManager?.enable()
     }
 

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -198,6 +198,18 @@ public class TextView: NSView, NSTextContent {
         }
     }
 
+    /// The attributes used to render marked text.
+    /// Defaults to a single underline.
+    public var markedTextAttributes: [NSAttributedString.Key: Any] {
+        get {
+            layoutManager.markedTextManager.markedTextAttributes
+        }
+        set {
+            layoutManager.markedTextManager.markedTextAttributes = newValue
+            layoutManager.layoutLines() // Layout lines to refresh attributes. This should be rare.
+        }
+    }
+
     open var contentType: NSTextContentType?
 
     /// The text view's delegate.

--- a/Tests/CodeEditTextViewTests/LineEndingTests.swift
+++ b/Tests/CodeEditTextViewTests/LineEndingTests.swift
@@ -43,7 +43,7 @@ class LineEndingTests: XCTestCase {
     func makeRandomText(_ goalLineEnding: LineEnding) -> String {
         (10..<Int.random(in: 20..<100)).reduce("") { partialResult, _ in
             return partialResult + String(
-                (0..<Int.random(in: 1..<20)).map{ _ in corpus.randomElement()! }
+                (0..<Int.random(in: 1..<20)).map { _ in corpus.randomElement()! }
             ) + goalLineEnding.rawValue
         }
     }

--- a/Tests/CodeEditTextViewTests/LineEndingTests.swift
+++ b/Tests/CodeEditTextViewTests/LineEndingTests.swift
@@ -1,8 +1,6 @@
 import XCTest
 @testable import CodeEditTextView
 
-// swiftlint:disable all
-
 class LineEndingTests: XCTestCase {
     func test_lineEndingCreateUnix() {
         // The \n character
@@ -29,64 +27,57 @@ class LineEndingTests: XCTestCase {
     }
 
     func test_detectLineEndingDefault() {
-        // There was a bug in this that caused it to flake sometimes, so we run this a couple times to ensure it's not flaky.
+        // There was a bug in this that caused it to flake sometimes, so we run this a couple times to ensure it's not
+        // flaky.
         // The odds of it being bad with the earlier bug after running 20 times is incredibly small
         for _ in 0..<20 {
             let storage = NSTextStorage(string: "hello world") // No line ending
             let lineStorage = TextLineStorage<TextLine>()
             lineStorage.buildFromTextStorage(storage, estimatedLineHeight: 10)
             let detected = LineEnding.detectLineEnding(lineStorage: lineStorage, textStorage: storage)
-            XCTAssertTrue(detected == .lineFeed, "Default detected line ending incorrect, expected: \n, got: \(detected.rawValue.debugDescription)")
+            XCTAssertEqual(detected, .lineFeed)
+        }
+    }
+
+    let corpus = "abcdefghijklmnopqrstuvwxyz123456789"
+    func makeRandomText(_ goalLineEnding: LineEnding) -> String {
+        (10..<Int.random(in: 20..<100)).reduce("") { partialResult, _ in
+            return partialResult + String(
+                (0..<Int.random(in: 1..<20)).map{ _ in corpus.randomElement()! }
+            ) + goalLineEnding.rawValue
         }
     }
 
     func test_detectLineEndingUnix() {
-        let corpus = "abcdefghijklmnopqrstuvwxyz123456789"
         let goalLineEnding = LineEnding.lineFeed
 
-        let text = (10..<Int.random(in: 20..<100)).reduce("") { partialResult, _ in
-            return partialResult + String((0..<Int.random(in: 1..<20)).map{ _ in corpus.randomElement()! }) + goalLineEnding.rawValue
-        }
-
-        let storage = NSTextStorage(string: text)
+        let storage = NSTextStorage(string: makeRandomText(goalLineEnding))
         let lineStorage = TextLineStorage<TextLine>()
         lineStorage.buildFromTextStorage(storage, estimatedLineHeight: 10)
 
         let detected = LineEnding.detectLineEnding(lineStorage: lineStorage, textStorage: storage)
-        XCTAssertTrue(detected == goalLineEnding, "Incorrect detected line ending, expected: \(goalLineEnding.rawValue.debugDescription), got \(detected.rawValue.debugDescription)")
+        XCTAssertEqual(detected, goalLineEnding)
     }
 
     func test_detectLineEndingCLRF() {
-        let corpus = "abcdefghijklmnopqrstuvwxyz123456789"
         let goalLineEnding = LineEnding.carriageReturnLineFeed
 
-        let text = (10..<Int.random(in: 20..<100)).reduce("") { partialResult, _ in
-            return partialResult + String((0..<Int.random(in: 1..<20)).map{ _ in corpus.randomElement()! }) + goalLineEnding.rawValue
-        }
-
-        let storage = NSTextStorage(string: text)
+        let storage = NSTextStorage(string: makeRandomText(goalLineEnding))
         let lineStorage = TextLineStorage<TextLine>()
         lineStorage.buildFromTextStorage(storage, estimatedLineHeight: 10)
 
         let detected = LineEnding.detectLineEnding(lineStorage: lineStorage, textStorage: storage)
-        XCTAssertTrue(detected == goalLineEnding, "Incorrect detected line ending, expected: \(goalLineEnding.rawValue.debugDescription), got \(detected.rawValue.debugDescription)")
+        XCTAssertEqual(detected, goalLineEnding)
     }
 
     func test_detectLineEndingMacOS() {
-        let corpus = "abcdefghijklmnopqrstuvwxyz123456789"
         let goalLineEnding = LineEnding.carriageReturn
 
-        let text = (10..<Int.random(in: 20..<100)).reduce("") { partialResult, _ in
-            return partialResult + String((0..<Int.random(in: 1..<20)).map{ _ in corpus.randomElement()! }) + goalLineEnding.rawValue
-        }
-
-        let storage = NSTextStorage(string: text)
+        let storage = NSTextStorage(string: makeRandomText(goalLineEnding))
         let lineStorage = TextLineStorage<TextLine>()
         lineStorage.buildFromTextStorage(storage, estimatedLineHeight: 10)
 
         let detected = LineEnding.detectLineEnding(lineStorage: lineStorage, textStorage: storage)
-        XCTAssertTrue(detected == goalLineEnding, "Incorrect detected line ending, expected: \(goalLineEnding.rawValue.debugDescription), got \(detected.rawValue.debugDescription)")
+        XCTAssertEqual(detected, goalLineEnding)
     }
 }
-
-// swiftlint:enable all

--- a/Tests/CodeEditTextViewTests/MarkedTextTests.swift
+++ b/Tests/CodeEditTextViewTests/MarkedTextTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import CodeEditTextView
+
+class MarkedTextTests: XCTestCase {
+    func test_markedTextSingleChar() {
+        let textView = TextView(string: "")
+        textView.selectionManager.setSelectedRange(.zero)
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "´")
+
+        textView.insertText("é", replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "é")
+        XCTAssertEqual(textView.selectionManager.textSelections.map(\.range), [NSRange(location: 1, length: 0)])
+    }
+
+    func test_markedTextSingleCharInStrings() {
+        let textView = TextView(string: "Lorem Ipsum")
+        textView.selectionManager.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "Lorem´ Ipsum")
+
+        textView.insertText("é", replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "Loremé Ipsum")
+        XCTAssertEqual(textView.selectionManager.textSelections.map(\.range), [NSRange(location: 6, length: 0)])
+    }
+
+    func test_markedTextReplaceSelection() {
+        let textView = TextView(string: "ABCDE")
+        textView.selectionManager.setSelectedRange(NSRange(location: 4, length: 1))
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "ABCD´")
+
+        textView.insertText("é", replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "ABCDé")
+        XCTAssertEqual(textView.selectionManager.textSelections.map(\.range), [NSRange(location: 5, length: 0)])
+    }
+
+    func test_markedTextMultipleSelection() {
+        let textView = TextView(string: "ABC")
+        textView.selectionManager.setSelectedRanges([NSRange(location: 1, length: 0), NSRange(location: 2, length: 0)])
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "A´B´C")
+
+        textView.insertText("é", replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "AéBéC")
+        XCTAssertEqual(
+            textView.selectionManager.textSelections.map(\.range).sorted(by: { $0.location < $1.location }),
+            [NSRange(location: 2, length: 0), NSRange(location: 4, length: 0)]
+        )
+    }
+
+    func test_markedTextMultipleSelectionReplaceSelection() {
+        let textView = TextView(string: "ABCDE")
+        textView.selectionManager.setSelectedRanges([NSRange(location: 0, length: 1), NSRange(location: 4, length: 1)])
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "´BCD´")
+
+        textView.insertText("é", replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "éBCDé")
+        XCTAssertEqual(
+            textView.selectionManager.textSelections.map(\.range).sorted(by: { $0.location < $1.location }),
+            [NSRange(location: 1, length: 0), NSRange(location: 5, length: 0)]
+        )
+    }
+
+    func test_cancelMarkedText() {
+        let textView = TextView(string: "")
+        textView.selectionManager.setSelectedRange(.zero)
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "´")
+
+        // The NSTextInputContext performs the following actions when a marked text segment is ended w/o replacing the
+        // marked text:
+        textView.insertText("´", replacementRange: .notFound)
+        textView.insertText("4", replacementRange: .notFound)
+
+        XCTAssertEqual(textView.string, "´4")
+        XCTAssertEqual(textView.selectionManager.textSelections.map(\.range), [NSRange(location: 2, length: 0)])
+    }
+
+    func test_cancelMarkedTextMultipleCursor() {
+        let textView = TextView(string: "ABC")
+        textView.selectionManager.setSelectedRanges([NSRange(location: 1, length: 0), NSRange(location: 2, length: 0)])
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "A´B´C")
+
+        // The NSTextInputContext performs the following actions when a marked text segment is ended w/o replacing the
+        // marked text:
+        textView.insertText("´", replacementRange: .notFound)
+        textView.insertText("4", replacementRange: .notFound)
+
+        XCTAssertEqual(textView.string, "A´4B´4C")
+        XCTAssertEqual(
+            textView.selectionManager.textSelections.map(\.range),
+            [NSRange(location: 3, length: 0), NSRange(location: 6, length: 0)]
+        )
+    }
+}

--- a/Tests/CodeEditTextViewTests/MarkedTextTests.swift
+++ b/Tests/CodeEditTextViewTests/MarkedTextTests.swift
@@ -98,7 +98,7 @@ class MarkedTextTests: XCTestCase {
 
         XCTAssertEqual(textView.string, "A´4B´4C")
         XCTAssertEqual(
-            textView.selectionManager.textSelections.map(\.range),
+            textView.selectionManager.textSelections.map(\.range).sorted(by: { $0.location < $1.location }),
             [NSRange(location: 3, length: 0), NSRange(location: 6, length: 0)]
         )
     }

--- a/Tests/CodeEditTextViewTests/MarkedTextTests.swift
+++ b/Tests/CodeEditTextViewTests/MarkedTextTests.swift
@@ -68,6 +68,28 @@ class MarkedTextTests: XCTestCase {
         )
     }
 
+    func test_markedTextMultipleSelectionMultipleChar() {
+        let textView = TextView(string: "ABCDE")
+        textView.selectionManager.setSelectedRanges([NSRange(location: 0, length: 1), NSRange(location: 4, length: 1)])
+
+        textView.setMarkedText("´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "´BCD´")
+
+        textView.setMarkedText("´´´", selectedRange: .notFound, replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "´´´BCD´´´")
+        XCTAssertEqual(
+            textView.selectionManager.textSelections.map(\.range).sorted(by: { $0.location < $1.location }),
+            [NSRange(location: 3, length: 0), NSRange(location: 9, length: 0)]
+        )
+
+        textView.insertText("é", replacementRange: .notFound)
+        XCTAssertEqual(textView.string, "éBCDé")
+        XCTAssertEqual(
+            textView.selectionManager.textSelections.map(\.range).sorted(by: { $0.location < $1.location }),
+            [NSRange(location: 1, length: 0), NSRange(location: 5, length: 0)]
+        )
+    }
+
     func test_cancelMarkedText() {
         let textView = TextView(string: "")
         textView.selectionManager.setSelectedRange(.zero)

--- a/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
+++ b/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
@@ -1,8 +1,6 @@
 import XCTest
 @testable import CodeEditTextView
 
-// swiftlint:disable function_body_length
-
 fileprivate extension CGFloat {
     func approxEqual(_ value: CGFloat) -> Bool {
         return abs(self - value) < 0.05
@@ -141,6 +139,7 @@ final class TextLayoutLineStorageTests: XCTestCase {
         }
     }
 
+    // swiflint:disable:next function_body_length
     func test_delete() throws {
         var tree = TextLineStorage<TextLine>()
 
@@ -274,5 +273,3 @@ final class TextLayoutLineStorageTests: XCTestCase {
         }
     }
 }
-
-// swiftlint:enable function_body_length

--- a/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
+++ b/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
@@ -139,7 +139,7 @@ final class TextLayoutLineStorageTests: XCTestCase {
         }
     }
 
-    // swiflint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length
     func test_delete() throws {
         var tree = TextLineStorage<TextLine>()
 


### PR DESCRIPTION
### Description

Fixes marked text input for sequences longer than one marked character. Also ensures marked text works consistently with multiple cursors and adds testing for the marked text functionality.

Also:
- Fixes a few lint markers in test files that have caused issues for others.
- Adds a public `TextView.markedTextAttributes` property for modifying the marked text attributes if desired.

### Related Issues

* closes #37 
* closes #36 
* closes #26 
* closes https://github.com/CodeEditApp/CodeEditSourceEditor/issues/188

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/CodeEditApp/CodeEditTextView/assets/35942988/9f6eb84b-c668-45a4-9d30-75cbd5d4fccd
