### PR TITLE
Remove Problematic CATransaction, Fix Lines Disappearing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "mainoffender",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattmassicotte/MainOffender",
-      "state" : {
-        "revision" : "343cc3797618c29b48b037b4e2beea0664e75315",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "rearrange",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/Rearrange",
       "state" : {
-        "revision" : "8f97f721d8a08c6e01ab9f7460e53819bef72dfa",
-        "version" : "1.5.3"
+        "revision" : "5ff7f3363f7a08f77e0d761e38e6add31c2136e1",
+        "version" : "1.8.1"
       }
     },
     {
@@ -23,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
+        "version" : "1.1.3"
       }
     },
     {
@@ -32,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
-        "revision" : "f69b412a765396d44dc9f4788a5b79919c1ca9e3",
-        "version" : "0.2.2"
+        "revision" : "5a65f4074975f811da666dfe31a19850950b1ea4",
+        "version" : "0.56.2"
       }
     },
     {
@@ -41,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/TextStory",
       "state" : {
-        "revision" : "8883fa739aa213e70e6cb109bfbf0a0b551e4cb5",
-        "version" : "0.8.0"
+        "revision" : "8dc9148b46fcf93b08ea9d4ef9bdb5e4f700e008",
+        "version" : "0.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // Text mutation, storage helpers
         .package(
             url: "https://github.com/ChimeHQ/TextStory",
-            from: "0.8.0"
+            from: "0.9.0"
         ),
         // Useful data structures
         .package(
@@ -27,7 +27,7 @@ let package = Package(
         // SwiftLint
         .package(
             url: "https://github.com/lukepistrol/SwiftLintPlugin",
-            from: "0.2.2"
+            from: "0.52.2"
         )
     ],
     targets: [

--- a/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -38,8 +38,8 @@ extension TextView {
             delegate?.textView(self, didReplaceContentsIn: range, with: string)
         }
 
-        layoutManager.endTransaction()
         textStorage.endEditing()
+        layoutManager.endTransaction()
         selectionManager.notifyAfterEdit()
         NotificationCenter.default.post(name: Self.textDidChangeNotification, object: self)
     }


### PR DESCRIPTION
### Description

Fixes a bug where line fragment views were being removed from layout despite the lines still existing. This was caused by overlapping `layoutLines` calls in the layout manager, which in turn were caused by a `CATransaction.commit()` call. This transaction was unnecessary and was removed. 

When `commit()` was called, the text view's `NSView.layout` method was triggered, causing layout again starting in the middle of the existing layout pass. However, the layout is not reentrant and this caused some line fragment views to be marked as missing and subsequently removed.

To prevent errors similar to this in the future, a debug-only flag was added during layout and is asserted when layout begins.

### Related Issues

* closes #47
* #48, not sure if this closes it but it looks like it might be similar after the changes in #40.
* closes https://github.com/CodeEditApp/CodeEdit/issues/1897

### Checklist

-  [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/dd131594-a4cf-4581-9ef8-928dfa50de5f
