### PR TITLE
Fix Padding Issue, Assertion Failure On Width Update

### DIFF
--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
@@ -13,7 +13,7 @@ extension TextLayoutManager {
     }
 
     public func estimatedWidth() -> CGFloat {
-        maxLineWidth
+        maxLineWidth + edgeInsets.horizontal
     }
 
     /// Finds a text line for the given y position relative to the text view.

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
@@ -266,10 +266,6 @@ public class TextLayoutManager: NSObject {
         // Update the visible lines with the new set.
         visibleLineIds = newVisibleLines
 
-        if originalHeight != lineStorage.height || layoutView?.frame.size.height != lineStorage.height {
-            delegate?.layoutManagerHeightDidUpdate(newHeight: lineStorage.height)
-        }
-
         if maxFoundLineWidth > maxLineWidth {
             maxLineWidth = maxFoundLineWidth
         }
@@ -282,6 +278,11 @@ public class TextLayoutManager: NSObject {
         isInLayout = false
         #endif
         needsLayout = false
+
+        // This needs to happen after ``needsLayout`` is toggled. Things can be triggered by frame changes.
+        if originalHeight != lineStorage.height || layoutView?.frame.size.height != lineStorage.height {
+            delegate?.layoutManagerHeightDidUpdate(newHeight: lineStorage.height)
+        }
     }
 
     /// Lays out a single text line.

--- a/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -83,7 +83,7 @@ extension TextView {
         if didUpdate {
             needsLayout = true
             needsDisplay = true
-            layoutManager.layoutLines()
+            layoutManager.setNeedsLayout()
         }
 
         if isSelectable {


### PR DESCRIPTION
### Description

- Considers the edge insets when calculating the 'max width' in the layout manager. Fixes a bug where trailing text is clipped when not wrapping lines because the width of the text view is not large enough.
- Fixes a potential assertion failure when notifying of a width update from the layout manager. Moves the delegate call to outside the protected area so that anything that may need to respond to a width adjustment can cause a layout pass without causing an invalid state.

### Related Issues

- https://github.com/CodeEditApp/CodeEditSourceEditor/pull/272

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A