### PR TITLE
Move All Delegate Calls Outside Layout Pass

### DIFF
--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
@@ -266,6 +266,13 @@ public class TextLayoutManager: NSObject {
         // Update the visible lines with the new set.
         visibleLineIds = newVisibleLines
 
+        #if DEBUG
+        isInLayout = false
+        #endif
+
+        // These are fine to update outside of `isInLayout` as our internal data structures are finalized at this point
+        // so laying out again won't break our line storage or visible line.
+
         if maxFoundLineWidth > maxLineWidth {
             maxLineWidth = maxFoundLineWidth
         }
@@ -274,15 +281,11 @@ public class TextLayoutManager: NSObject {
             delegate?.layoutManagerYAdjustment(yContentAdjustment)
         }
 
-        #if DEBUG
-        isInLayout = false
-        #endif
-        needsLayout = false
-
-        // This needs to happen after ``needsLayout`` is toggled. Things can be triggered by frame changes.
         if originalHeight != lineStorage.height || layoutView?.frame.size.height != lineStorage.height {
             delegate?.layoutManagerHeightDidUpdate(newHeight: lineStorage.height)
         }
+
+        needsLayout = false
     }
 
     /// Lays out a single text line.

--- a/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -58,6 +58,8 @@ extension TextView {
         inputContext?.invalidateCharacterCoordinates()
     }
 
+    /// Updates the view's frame if needed depending on wrapping lines, a new maximum width, or changed available size.
+    /// - Returns: Whether or not the view was updated.
     @discardableResult
     public func updateFrameIfNeeded() -> Bool {
         var availableSize = scrollView?.contentSize ?? .zero


### PR DESCRIPTION
### Description

Moves a few more delegate calls or delegate triggering calls outside the protected area in `layoutLines` to prevent crashes. These are safe to call outside the intended protected area.

Also documents an important layout method.

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A