### PR TITLE
Inset Selection Rect By Leading Edge

### DIFF
--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 extension TextSelectionManager {
-    /// Calculate a set of rects for a text selection suitable for filling with the selection color to indicate a multi-line selection.
+    /// Calculate a set of rects for a text selection suitable for filling with the selection color to indicate a
+    /// multi-line selection.
     ///
     /// The returned rects are inset by edge insets passed to the text view, the given `rect` parameter can be the 'raw'
     /// rect to draw in, no need to inset it before this method call.

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
@@ -38,7 +38,7 @@ extension TextSelectionManager {
 
         if firstLinePosition.yPos + firstLinePosition.height < lastLinePosition.yPos {
             fillRects.append(CGRect(
-                x: rect.minX,
+                x: max(layoutManager.edgeInsets.left, rect.minX),
                 y: firstLinePosition.yPos + firstLinePosition.height,
                 width: rect.width,
                 height: lastLinePosition.yPos - (firstLinePosition.yPos + firstLinePosition.height)


### PR DESCRIPTION
### Description

Insets the drawn selection box by the text view's edge insets. 

### Related Issues

* #59 

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/user-attachments/assets/74f8a8bd-4467-4b65-b068-96544c230dad


