### PR TITLE
Add Text Insets

### DIFF
--- a/Example/CodeEditTextViewExample/CodeEditTextViewExample.xcodeproj/project.pbxproj
+++ b/Example/CodeEditTextViewExample/CodeEditTextViewExample.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 				CODE_SIGN_ENTITLEMENTS = CodeEditTextViewExample/CodeEditTextViewExample.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"CodeEditTextViewExample/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -226,7 +226,7 @@
 				CODE_SIGN_ENTITLEMENTS = CodeEditTextViewExample/CodeEditTextViewExample.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"CodeEditTextViewExample/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Example/CodeEditTextViewExample/CodeEditTextViewExample/Views/ContentView.swift
+++ b/Example/CodeEditTextViewExample/CodeEditTextViewExample/Views/ContentView.swift
@@ -9,9 +9,18 @@ import SwiftUI
 
 struct ContentView: View {
     @Binding var document: CodeEditTextViewExampleDocument
+    @AppStorage("wraplines") private var wrapLines: Bool = true
+    @AppStorage("edgeinsets") private var enableEdgeInsets: Bool = false
 
     var body: some View {
-        SwiftUITextView(text: $document.text)
+        VStack(spacing: 0) {
+            HStack {
+                Toggle("Wrap Lines", isOn: $wrapLines)
+                Toggle("Inset Edges", isOn: $enableEdgeInsets)
+            }
+            Divider()
+            SwiftUITextView(text: $document.text, wrapLines: $wrapLines, enableEdgeInsets: $enableEdgeInsets)
+        }
     }
 }
 

--- a/Example/CodeEditTextViewExample/CodeEditTextViewExample/Views/SwiftUITextView.swift
+++ b/Example/CodeEditTextViewExample/CodeEditTextViewExample/Views/SwiftUITextView.swift
@@ -11,15 +11,20 @@ import CodeEditTextView
 
 struct SwiftUITextView: NSViewControllerRepresentable {
     @Binding var text: String
+    @Binding var wrapLines: Bool
+    @Binding var enableEdgeInsets: Bool
 
     func makeNSViewController(context: Context) -> TextViewController {
         let controller = TextViewController(string: text)
         context.coordinator.controller = controller
+        controller.wrapLines = wrapLines
+        controller.enableEdgeInsets = enableEdgeInsets
         return controller
     }
 
     func updateNSViewController(_ nsViewController: TextViewController, context: Context) {
-        // Do nothing, our binding has to be a one-way binding
+        nsViewController.wrapLines = wrapLines
+        nsViewController.enableEdgeInsets = enableEdgeInsets
     }
 
     func makeCoordinator() -> Coordinator {

--- a/Example/CodeEditTextViewExample/CodeEditTextViewExample/Views/TextViewController.swift
+++ b/Example/CodeEditTextViewExample/CodeEditTextViewExample/Views/TextViewController.swift
@@ -11,6 +11,22 @@ import CodeEditTextView
 class TextViewController: NSViewController {
     var scrollView: NSScrollView!
     var textView: TextView!
+    var enableEdgeInsets: Bool = false {
+        didSet {
+            if enableEdgeInsets {
+                textView.edgeInsets = .init(left: 20, right: 30)
+                textView.textInsets = .init(left: 10, right: 30)
+            } else {
+                textView.edgeInsets = .zero
+                textView.textInsets = .zero
+            }
+        }
+    }
+    var wrapLines: Bool = true {
+        didSet {
+            textView.wrapLines = wrapLines
+        }
+    }
 
     init(string: String) {
         textView = TextView(string: string)
@@ -24,6 +40,14 @@ class TextViewController: NSViewController {
     override func loadView() {
         scrollView = NSScrollView()
         textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.wrapLines = wrapLines
+        if enableEdgeInsets {
+            textView.edgeInsets = .init(left: 30, right: 30)
+            textView.textInsets = .init(left: 0, right: 30)
+        } else {
+            textView.edgeInsets = .zero
+            textView.textInsets = .zero
+        }
 
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.documentView = textView

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Draw.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Draw.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  TextSelectionManager+Draw.swift
 //  CodeEditTextView
 //
 //  Created by Khan Winter on 1/12/25.

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Draw.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Draw.swift
@@ -1,0 +1,97 @@
+//
+//  File.swift
+//  CodeEditTextView
+//
+//  Created by Khan Winter on 1/12/25.
+//
+
+import AppKit
+
+extension TextSelectionManager {
+    /// Draws line backgrounds and selection rects for each selection in the given rect.
+    /// - Parameter rect: The rect to draw in.
+    func drawSelections(in rect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        context.saveGState()
+        var highlightedLines: Set<UUID> = []
+        // For each selection in the rect
+        for textSelection in textSelections {
+            if textSelection.range.isEmpty {
+                drawHighlightedLine(
+                    in: rect,
+                    for: textSelection,
+                    context: context,
+                    highlightedLines: &highlightedLines
+                )
+            } else {
+                drawSelectedRange(in: rect, for: textSelection, context: context)
+            }
+        }
+        context.restoreGState()
+    }
+
+    /// Draws a highlighted line in the given rect.
+    /// - Parameters:
+    ///   - rect: The rect to draw in.
+    ///   - textSelection: The selection to draw.
+    ///   - context: The context to draw in.
+    ///   - highlightedLines: The set of all lines that have already been highlighted, used to avoid highlighting lines
+    ///                       twice and updated if this function comes across a new line id.
+    private func drawHighlightedLine(
+        in rect: NSRect,
+        for textSelection: TextSelection,
+        context: CGContext,
+        highlightedLines: inout Set<UUID>
+    ) {
+        guard let linePosition = layoutManager?.textLineForOffset(textSelection.range.location),
+              !highlightedLines.contains(linePosition.data.id) else {
+            return
+        }
+        highlightedLines.insert(linePosition.data.id)
+        context.saveGState()
+
+        let insetXPos = max(rect.minX, edgeInsets.left)
+        let maxWidth = (textView?.frame.width ?? 0) - insetXPos - edgeInsets.right
+
+        let selectionRect = CGRect(
+            x: insetXPos,
+            y: linePosition.yPos,
+            width: min(rect.width, maxWidth),
+            height: linePosition.height
+        ).pixelAligned
+
+        if selectionRect.intersects(rect) {
+            context.setFillColor(selectedLineBackgroundColor.cgColor)
+            context.fill(selectionRect)
+        }
+        context.restoreGState()
+    }
+
+    /// Draws a selected range in the given context.
+    /// - Parameters:
+    ///   - rect: The rect to draw in.
+    ///   - range: The range to highlight.
+    ///   - context: The context to draw in.
+    private func drawSelectedRange(in rect: NSRect, for textSelection: TextSelection, context: CGContext) {
+        context.saveGState()
+
+        let fillColor = (textView?.isFirstResponder ?? false)
+        ? selectionBackgroundColor.cgColor
+        : selectionBackgroundColor.grayscale.cgColor
+
+        context.setFillColor(fillColor)
+
+        let fillRects = getFillRects(in: rect, for: textSelection)
+
+        let minX = fillRects.min(by: { $0.origin.x < $1.origin.x })?.origin.x ?? 0
+        let minY = fillRects.min(by: { $0.origin.y < $1.origin.y })?.origin.y ?? 0
+        let max = fillRects.max(by: { $0.maxY < $1.maxY }) ?? .zero
+        let origin = CGPoint(x: minX, y: minY)
+        let size = CGSize(width: max.maxX - minX, height: max.maxY - minY)
+        textSelection.boundingRect = CGRect(origin: origin, size: size)
+
+        context.fill(fillRects)
+        context.restoreGState()
+    }
+
+}

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
@@ -30,8 +30,8 @@ extension TextSelectionManager {
             return []
         }
 
-        let insetXPos = max(layoutManager.edgeInsets.left, rect.minX)
-        let insetWidth = max(0, rect.maxX - insetXPos - layoutManager.edgeInsets.right)
+        let insetXPos = max(edgeInsets.left, rect.minX)
+        let insetWidth = max(0, rect.maxX - insetXPos - edgeInsets.right)
         let insetRect = NSRect(x: insetXPos, y: rect.origin.y, width: insetWidth, height: rect.height)
 
         // Calculate the first line and any rects selected

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -38,6 +38,13 @@ public class TextSelectionManager: NSObject {
         }
     }
 
+    /// Determines how far inset to draw selection content.
+    public var edgeInsets: HorizontalEdgeInsets = .zero {
+        didSet {
+            delegate?.setNeedsDisplay()
+        }
+    }
+
     internal(set) public var textSelections: [TextSelection] = []
     weak var layoutManager: TextLayoutManager?
     weak var textStorage: NSTextStorage?
@@ -223,88 +230,5 @@ public class TextSelectionManager: NSObject {
         for textSelection in textSelections {
             textSelection.view?.removeFromSuperview()
         }
-    }
-
-    // MARK: - Draw
-
-    /// Draws line backgrounds and selection rects for each selection in the given rect.
-    /// - Parameter rect: The rect to draw in.
-    func drawSelections(in rect: NSRect) {
-        guard let context = NSGraphicsContext.current?.cgContext else { return }
-        context.saveGState()
-        var highlightedLines: Set<UUID> = []
-        // For each selection in the rect
-        for textSelection in textSelections {
-            if textSelection.range.isEmpty {
-                drawHighlightedLine(
-                    in: rect,
-                    for: textSelection,
-                    context: context,
-                    highlightedLines: &highlightedLines
-                )
-            } else {
-                drawSelectedRange(in: rect, for: textSelection, context: context)
-            }
-        }
-        context.restoreGState()
-    }
-
-    /// Draws a highlighted line in the given rect.
-    /// - Parameters:
-    ///   - rect: The rect to draw in.
-    ///   - textSelection: The selection to draw.
-    ///   - context: The context to draw in.
-    ///   - highlightedLines: The set of all lines that have already been highlighted, used to avoid highlighting lines
-    ///                       twice and updated if this function comes across a new line id.
-    private func drawHighlightedLine(
-        in rect: NSRect,
-        for textSelection: TextSelection,
-        context: CGContext,
-        highlightedLines: inout Set<UUID>
-    ) {
-        guard let linePosition = layoutManager?.textLineForOffset(textSelection.range.location),
-              !highlightedLines.contains(linePosition.data.id) else {
-            return
-        }
-        highlightedLines.insert(linePosition.data.id)
-        context.saveGState()
-        let selectionRect = CGRect(
-            x: rect.minX,
-            y: linePosition.yPos,
-            width: rect.width,
-            height: linePosition.height
-        )
-        if selectionRect.intersects(rect) {
-            context.setFillColor(selectedLineBackgroundColor.cgColor)
-            context.fill(selectionRect)
-        }
-        context.restoreGState()
-    }
-
-    /// Draws a selected range in the given context.
-    /// - Parameters:
-    ///   - rect: The rect to draw in.
-    ///   - range: The range to highlight.
-    ///   - context: The context to draw in.
-    private func drawSelectedRange(in rect: NSRect, for textSelection: TextSelection, context: CGContext) {
-        context.saveGState()
-
-        let fillColor = (textView?.isFirstResponder ?? false)
-        ? selectionBackgroundColor.cgColor
-        : selectionBackgroundColor.grayscale.cgColor
-
-        context.setFillColor(fillColor)
-
-        let fillRects = getFillRects(in: rect, for: textSelection)
-
-        let minX = fillRects.min(by: { $0.origin.x < $1.origin.x })?.origin.x ?? 0
-        let minY = fillRects.min(by: { $0.origin.y < $1.origin.y })?.origin.y ?? 0
-        let max = fillRects.max(by: { $0.maxY < $1.maxY }) ?? .zero
-        let origin = CGPoint(x: minX, y: minY)
-        let size = CGSize(width: max.maxX - minX, height: max.maxY - minY)
-        textSelection.boundingRect = CGRect(origin: origin, size: size)
-
-        context.fill(fillRects)
-        context.restoreGState()
     }
 }

--- a/Sources/CodeEditTextView/TextView/TextView+SetText.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+SetText.swift
@@ -1,0 +1,40 @@
+//
+//  TextView+SetText.swift
+//  CodeEditTextView
+//
+//  Created by Khan Winter on 1/12/25.
+//
+
+import AppKit
+
+extension TextView {
+    /// Sets the text view's text to a new value.
+    /// - Parameter text: The new contents of the text view.
+    public func setText(_ text: String) {
+        let newStorage = NSTextStorage(string: text)
+        self.setTextStorage(newStorage)
+    }
+
+    /// Set a new text storage object for the view.
+    /// - Parameter textStorage: The new text storage to use.
+    public func setTextStorage(_ textStorage: NSTextStorage) {
+        self.textStorage = textStorage
+
+        subviews.forEach { view in
+            view.removeFromSuperview()
+        }
+
+        textStorage.addAttributes(typingAttributes, range: documentRange)
+        layoutManager.textStorage = textStorage
+        layoutManager.reset()
+
+        selectionManager.textStorage = textStorage
+        selectionManager.setSelectedRanges(selectionManager.textSelections.map { $0.range })
+
+        _undoManager?.clearStack()
+
+        textStorage.delegate = storageDelegate
+        needsDisplay = true
+        needsLayout = true
+    }
+}

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -150,13 +150,28 @@ public class TextView: NSView, NSTextContent {
         }
     }
 
-    /// The edge insets for the text view.
+    /// The edge insets for the text view. This value insets every piece of drawable content in the view, including
+    /// selection rects.
+    ///
+    /// To further inset the text from the edge, without modifying how selections are inset, use ``textInsets``
     public var edgeInsets: HorizontalEdgeInsets {
         get {
-            layoutManager?.edgeInsets ?? .zero
+            selectionManager.edgeInsets
         }
         set {
-            layoutManager?.edgeInsets = newValue
+            layoutManager.edgeInsets = newValue + textInsets
+            selectionManager.edgeInsets = newValue
+        }
+    }
+
+    /// Insets just drawn text from the horizontal edges. This is in addition to the insets in ``edgeInsets``, but does
+    /// not apply to other drawn content.
+    public var textInsets: HorizontalEdgeInsets {
+        get {
+            layoutManager.edgeInsets - selectionManager.edgeInsets
+        }
+        set {
+            layoutManager.edgeInsets = edgeInsets + newValue
         }
     }
 

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -234,11 +234,11 @@ public class TextView: NSView, NSTextContent {
     /// - Warning: Do not update the text storage object directly. Doing so will very likely break the text view's
     ///            layout system. Use methods like ``TextView/replaceCharacters(in:with:)-58mt7`` or
     ///            ``TextView/insertText(_:)`` to modify content.
-    private(set) public var textStorage: NSTextStorage!
+    package(set) public var textStorage: NSTextStorage!
     /// The layout manager for the text view.
-    private(set) public var layoutManager: TextLayoutManager!
+    package(set) public var layoutManager: TextLayoutManager!
     /// The selection manager for the text view.
-    private(set) public var selectionManager: TextSelectionManager!
+    package(set) public var selectionManager: TextSelectionManager!
 
     /// Empasizse text ranges in the text view
     public var emphasizeAPI: EmphasizeAPI?
@@ -323,36 +323,6 @@ public class TextView: NSView, NSTextContent {
 
         layoutManager.layoutLines()
         setUpDragGesture()
-    }
-
-    /// Sets the text view's text to a new value.
-    /// - Parameter text: The new contents of the text view.
-    public func setText(_ text: String) {
-        let newStorage = NSTextStorage(string: text)
-        self.setTextStorage(newStorage)
-    }
-
-    /// Set a new text storage object for the view.
-    /// - Parameter textStorage: The new text storage to use.
-    public func setTextStorage(_ textStorage: NSTextStorage) {
-        self.textStorage = textStorage
-
-        subviews.forEach { view in
-            view.removeFromSuperview()
-        }
-
-        textStorage.addAttributes(typingAttributes, range: documentRange)
-        layoutManager.textStorage = textStorage
-        layoutManager.reset()
-
-        selectionManager.textStorage = textStorage
-        selectionManager.setSelectedRanges(selectionManager.textSelections.map { $0.range })
-
-        _undoManager?.clearStack()
-
-        textStorage.delegate = storageDelegate
-        needsDisplay = true
-        needsLayout = true
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/CodeEditTextView/Utils/HorizontalEdgeInsets.swift
+++ b/Sources/CodeEditTextView/Utils/HorizontalEdgeInsets.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct HorizontalEdgeInsets: Codable, Sendable, Equatable {
+public struct HorizontalEdgeInsets: Codable, Sendable, Equatable, AdditiveArithmetic {
     public var left: CGFloat
     public var right: CGFloat
 
@@ -29,4 +29,12 @@ public struct HorizontalEdgeInsets: Codable, Sendable, Equatable {
     public static let zero: HorizontalEdgeInsets = {
         HorizontalEdgeInsets(left: 0, right: 0)
     }()
+
+    public static func + (lhs: HorizontalEdgeInsets, rhs: HorizontalEdgeInsets) -> HorizontalEdgeInsets {
+        HorizontalEdgeInsets(left: lhs.left + rhs.left, right: lhs.right + rhs.right)
+    }
+
+    public static func - (lhs: HorizontalEdgeInsets, rhs: HorizontalEdgeInsets) -> HorizontalEdgeInsets {
+        HorizontalEdgeInsets(left: lhs.left - rhs.left, right: lhs.right - rhs.right)
+    }
 }


### PR DESCRIPTION
### Description

- Adds a `textInsets` property that allows insetting the drawn text further than other drawn content in the view.
  This works in addition to the `edgeInsets` property, and only effects where text is drawn. This enables adding a padded area where text is not drawn, and selections are not drawn, and further inset the text from that edge.
  This is useful when adding trailing padding to a text view that is not wrapping lines. In a case like that, the textview needs to have a larger width than just the text, but also needs to draw the selection rect in that padded area. To achieve this, the text inset would be set to the padded area.

### Related Issues

* Related to #59.
* Will facilitate what https://github.com/CodeEditApp/CodeEditSourceEditor/pull/272 attempted to do (the trailing padding) without introducing blank space on the trailing edge.

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Text insets and edge insets have left and right set to 30. All content is inset by 30px and the text is further inset by another 30px on the right side.

https://github.com/user-attachments/assets/6a79f224-45a8-413b-891b-27f6b509856b

An example of negative text insets on top of positive edge insets, showing it works as expected.

https://github.com/user-attachments/assets/28136cdb-6d7a-49b2-97f1-d3435fe939c1

No wrapping lines, text inset is >0 on the right edge, meaning the textview has some room to scroll after the text, while still drawing the selection rect in some of that padded area.

https://github.com/user-attachments/assets/6635af28-2f51-46d8-b6d3-642d7bcb2f94

The updated example app with two new controls:

![Screenshot 2025-01-12 at 2 05 48 PM](https://github.com/user-attachments/assets/56dd316e-cdce-4b2e-89e6-f93dc6e1fa83)
