### PR TITLE
Added underscore to selection

### DIFF
--- a/Sources/CodeEditTextView/Extensions/CharacterSet.swift
+++ b/Sources/CodeEditTextView/Extensions/CharacterSet.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension CharacterSet {
-    /// Returns a character set containing the characters in common in code names
+    /// Returns a character set containing the characters common in code names
     static let codeIdentifierCharacters: CharacterSet = .alphanumerics
         .union(.init(charactersIn: "_"))
 }

--- a/Sources/CodeEditTextView/Extensions/CharacterSet.swift
+++ b/Sources/CodeEditTextView/Extensions/CharacterSet.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension CharacterSet {
+    /// Returns a character set containing the characters in common in code names
     static let codeIdentifierCharacters: CharacterSet = .alphanumerics
         .union(.init(charactersIn: "_"))
 }

--- a/Sources/CodeEditTextView/Extensions/CharacterSet.swift
+++ b/Sources/CodeEditTextView/Extensions/CharacterSet.swift
@@ -1,0 +1,13 @@
+//
+//  CharacterSet.swift
+//  CodeEditTextView
+//
+//  Created by Abe Malla on 3/29/25.
+//
+
+import Foundation
+
+extension CharacterSet {
+    static let codeIdentifierCharacters: CharacterSet = .alphanumerics
+        .union(.init(charactersIn: "_"))
+}

--- a/Sources/CodeEditTextView/TextSelectionManager/SelectionManipulation/SelectionManipulation+Horizontal.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/SelectionManipulation/SelectionManipulation+Horizontal.swift
@@ -109,10 +109,11 @@ package extension TextSelectionManager {
 
             if hasFoundValidWordChar && CharacterSet.punctuationCharacters
                 .union(.whitespacesAndNewlines)
+                .subtracting(CharacterSet.codeIdentifierCharacters)
                 .isSuperset(of: CharacterSet(charactersIn: substring)) {
                 stop.pointee = true
                 return
-            } else if CharacterSet.alphanumerics.isSuperset(of: CharacterSet(charactersIn: substring)) {
+            } else if CharacterSet.codeIdentifierCharacters.isSuperset(of: CharacterSet(charactersIn: substring)) {
                 hasFoundValidWordChar = true
             }
             rangeToDelete.length += substring.count

--- a/Sources/CodeEditTextView/TextView/TextView+Select.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Select.swift
@@ -37,8 +37,8 @@ extension TextView {
             }
             let charSet = CharacterSet(charactersIn: String(char))
             let characterSet: CharacterSet
-            if CharacterSet.alphanumerics.isSuperset(of: charSet) {
-                characterSet = .alphanumerics
+            if CharacterSet.codeIdentifierCharacters.isSuperset(of: charSet) {
+                characterSet = .codeIdentifierCharacters
             } else if CharacterSet.whitespaces.isSuperset(of: charSet) {
                 characterSet = .whitespaces
             } else if CharacterSet.newlines.isSuperset(of: charSet) {


### PR DESCRIPTION
### Description

When selecting entire words, either through double clicking or through option+arrow keys, it will now consider underscores as part of the selection.

### Related Issues

Closes #72 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots



https://github.com/user-attachments/assets/a563586c-e7f2-420f-959d-de1110e2ae4e

