### PR TITLE
Added mouse drag selection modes

### DIFF
--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelection.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelection.swift
@@ -34,6 +34,12 @@ public extension TextSelectionManager {
             lhs.range == rhs.range
         }
     }
+
+    enum SelectionMode {
+        case character
+        case word
+        case line
+    }
 }
 
 private extension TextSelectionManager.TextSelection {

--- a/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
@@ -42,6 +42,8 @@ extension TextView {
     /// if shift, we extend the selection to the click location
     /// else we set the cursor
     fileprivate func handleSingleClick(event: NSEvent, offset: Int) {
+        selectionMode = .character
+
         guard isEditable else {
             super.mouseDown(with: event)
             return
@@ -59,6 +61,8 @@ extension TextView {
     }
 
     fileprivate func handleDoubleClick(event: NSEvent) {
+        selectionMode = .word
+
         guard !event.modifierFlags.contains(.shift) else {
             super.mouseDown(with: event)
             return
@@ -68,6 +72,8 @@ extension TextView {
     }
 
     fileprivate func handleTripleClick(event: NSEvent) {
+        selectionMode = .line
+
         guard !event.modifierFlags.contains(.shift) else {
             super.mouseDown(with: event)
             return
@@ -97,12 +103,43 @@ extension TextView {
                   let endPosition = layoutManager.textOffsetAtPoint(convert(event.locationInWindow, from: nil)) else {
                 return
             }
-            selectionManager.setSelectedRange(
-                NSRange(
-                    location: min(startPosition, endPosition),
-                    length: max(startPosition, endPosition) - min(startPosition, endPosition)
+
+            switch selectionMode {
+            case .character:
+                selectionManager.setSelectedRange(
+                    NSRange(
+                        location: min(startPosition, endPosition),
+                        length: max(startPosition, endPosition) - min(startPosition, endPosition)
+                    )
                 )
-            )
+
+            case .word:
+                let startWordRange = findWordBoundary(at: startPosition)
+                let endWordRange = findWordBoundary(at: endPosition)
+
+                selectionManager.setSelectedRange(
+                    NSRange(
+                        location: min(startWordRange.location, endWordRange.location),
+                        length: max(startWordRange.location + startWordRange.length,
+                                    endWordRange.location + endWordRange.length) -
+                                min(startWordRange.location, endWordRange.location)
+                    )
+                )
+
+            case .line:
+                let startLineRange = findLineBoundary(at: startPosition)
+                let endLineRange = findLineBoundary(at: endPosition)
+
+                selectionManager.setSelectedRange(
+                    NSRange(
+                        location: min(startLineRange.location, endLineRange.location),
+                        length: max(startLineRange.location + startLineRange.length,
+                                    endLineRange.location + endLineRange.length) -
+                                min(startLineRange.location, endLineRange.location)
+                    )
+                )
+            }
+
             setNeedsDisplay()
             self.autoscroll(with: event)
         }

--- a/Sources/CodeEditTextView/TextView/TextView+Select.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Select.swift
@@ -29,35 +29,53 @@ extension TextView {
 
     override public func selectWord(_ sender: Any?) {
         let newSelections = selectionManager.textSelections.compactMap { (textSelection) -> NSRange? in
-            guard textSelection.range.isEmpty,
-                  let char = textStorage.substring(
-                    from: NSRange(location: textSelection.range.location, length: 1)
-                  )?.first else {
-                return nil
+                guard textSelection.range.isEmpty else {
+                    return nil
+                }
+                return findWordBoundary(at: textSelection.range.location)
             }
-            let charSet = CharacterSet(charactersIn: String(char))
-            let characterSet: CharacterSet
-            if CharacterSet.codeIdentifierCharacters.isSuperset(of: charSet) {
-                characterSet = .codeIdentifierCharacters
-            } else if CharacterSet.whitespaces.isSuperset(of: charSet) {
-                characterSet = .whitespaces
-            } else if CharacterSet.newlines.isSuperset(of: charSet) {
-                characterSet = .newlines
-            } else if CharacterSet.punctuationCharacters.isSuperset(of: charSet) {
-                characterSet = .punctuationCharacters
-            } else {
-                return nil
-            }
-            guard let start = textStorage
-                .findPrecedingOccurrenceOfCharacter(in: characterSet.inverted, from: textSelection.range.location),
-                  let end = textStorage
-                .findNextOccurrenceOfCharacter(in: characterSet.inverted, from: textSelection.range.max) else {
-                return nil
-            }
-            return NSRange(start: start, end: end)
-        }
         selectionManager.setSelectedRanges(newSelections)
         unmarkTextIfNeeded()
         needsDisplay = true
+    }
+
+    /// Given a position, find the range of the word that exists at that position.
+    internal func findWordBoundary(at position: Int) -> NSRange {
+        guard position >= 0 && position < textStorage.length,
+              let char = textStorage.substring(
+                from: NSRange(location: position, length: 1)
+              )?.first else {
+            return NSRange(location: position, length: 0)
+        }
+
+        let charSet = CharacterSet(charactersIn: String(char))
+        let characterSet: CharacterSet
+
+        if CharacterSet.codeIdentifierCharacters.isSuperset(of: charSet) {
+            characterSet = .codeIdentifierCharacters
+        } else if CharacterSet.whitespaces.isSuperset(of: charSet) {
+            characterSet = .whitespaces
+        } else if CharacterSet.newlines.isSuperset(of: charSet) {
+            characterSet = .newlines
+        } else if CharacterSet.punctuationCharacters.isSuperset(of: charSet) {
+            characterSet = .punctuationCharacters
+        } else {
+            return NSRange(location: position, length: 0)
+        }
+
+        guard let start = textStorage.findPrecedingOccurrenceOfCharacter(in: characterSet.inverted, from: position),
+              let end = textStorage.findNextOccurrenceOfCharacter(in: characterSet.inverted, from: position) else {
+            return NSRange(location: position, length: 0)
+        }
+
+        return NSRange(start: start, end: end)
+    }
+
+    /// Given a position, find the range of the entire line that exists at that position.
+    internal func findLineBoundary(at position: Int) -> NSRange {
+        guard let linePosition = layoutManager.textLineForOffset(position) else {
+            return NSRange(location: position, length: 0)
+        }
+        return linePosition.range
     }
 }

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -248,6 +248,7 @@ public class TextView: NSView, NSTextContent {
     var isFirstResponder: Bool = false
     var mouseDragAnchor: CGPoint?
     var mouseDragTimer: Timer?
+    var selectionMode: TextSelectionManager.SelectionMode = .character
 
     private var fontCharWidth: CGFloat {
         (" " as NSString).size(withAttributes: [.font: font]).width


### PR DESCRIPTION
### Description

There are 3 different selection modes that editors typically have when clicking and dragging the mouse.
1. Character - simple click and drag to select by character
2. Word - double click a word and then drag to start selecting by word ranges
3. Line - triple click and drag to start selecting by entire lines

This PR tracks and implements the different selection mode behaviors.

### Related Issues

Closes #74 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Character selection (default behavior, unchanged)

https://github.com/user-attachments/assets/6f863cfb-35e9-4871-8dbb-9c21f97fdf47


Double click for word selection

https://github.com/user-attachments/assets/0c84ba50-0a0d-4e04-8b98-565cdcab8580

Triple click for line selection

https://github.com/user-attachments/assets/df700d71-e72e-4ea7-9c04-76d212009d1f

