### PR TITLE
Added scroll past end behavior (overscroll)

### DIFF
--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -221,7 +221,6 @@ public class TextSelectionManager: NSObject {
             .getLine(atOffset: range.location - (selectedLine.range.location))?
             .height
         ?? layoutManager?.estimateLineHeight()
-
     }
 
     /// Removes all cursor views and stops the cursor blink timer.

--- a/Sources/CodeEditTextView/TextView/TextView+Insert.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Insert.swift
@@ -6,7 +6,6 @@
 //
 
 import AppKit
-import TextStory
 
 extension TextView {
     override public func insertNewline(_ sender: Any?) {

--- a/Sources/CodeEditTextView/TextView/TextView+Insert.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Insert.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import TextStory
 
 extension TextView {
     override public func insertNewline(_ sender: Any?) {

--- a/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -65,7 +65,7 @@ extension TextView {
         var availableSize = scrollView?.contentSize ?? .zero
         availableSize.height -= (scrollView?.contentInsets.top ?? 0) + (scrollView?.contentInsets.bottom ?? 0)
 
-        let extraHeight = scrollPastEnd ? availableSize.height * scrollPastEndAmount : 0
+        let extraHeight = overscroll ? availableSize.height * overscrollAmount : 0
         let newHeight = max(layoutManager.estimatedHeight() + extraHeight, availableSize.height)
         let newWidth = layoutManager.estimatedWidth()
 

--- a/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -64,7 +64,9 @@ extension TextView {
     public func updateFrameIfNeeded() -> Bool {
         var availableSize = scrollView?.contentSize ?? .zero
         availableSize.height -= (scrollView?.contentInsets.top ?? 0) + (scrollView?.contentInsets.bottom ?? 0)
-        let newHeight = max(layoutManager.estimatedHeight(), availableSize.height)
+
+        let extraHeight = scrollPastEnd ? availableSize.height * scrollPastEndAmount : 0
+        let newHeight = max(layoutManager.estimatedHeight() + extraHeight, availableSize.height)
         let newWidth = layoutManager.estimatedWidth()
 
         var didUpdate = false

--- a/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -65,7 +65,7 @@ extension TextView {
         var availableSize = scrollView?.contentSize ?? .zero
         availableSize.height -= (scrollView?.contentInsets.top ?? 0) + (scrollView?.contentInsets.bottom ?? 0)
 
-        let extraHeight = overscroll ? availableSize.height * overscrollAmount : 0
+        let extraHeight = availableSize.height * overscrollAmount
         let newHeight = max(layoutManager.estimatedHeight() + extraHeight, availableSize.height)
         let newWidth = layoutManager.estimatedWidth()
 

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -107,6 +107,22 @@ public class TextView: NSView, NSTextContent {
         }
     }
 
+    /// Determines if the text view should allow scrolling past the end of the document
+    public var scrollPastEnd: Bool = true {
+        didSet {
+            updateFrameIfNeeded()
+        }
+    }
+
+    /// The amount of extra space to add when scrolling past end is enabled, as a percentage of the viewport height
+    public var scrollPastEndAmount: CGFloat = 0.5 {
+        didSet {
+            if scrollPastEnd {
+                updateFrameIfNeeded()
+            }
+        }
+    }
+
     /// Whether or not the editor should wrap lines
     public var wrapLines: Bool {
         get {

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -108,16 +108,16 @@ public class TextView: NSView, NSTextContent {
     }
 
     /// Determines if the text view should allow scrolling past the end of the document
-    public var scrollPastEnd: Bool = true {
+    public var overscroll: Bool = true {
         didSet {
             updateFrameIfNeeded()
         }
     }
 
     /// The amount of extra space to add when scrolling past end is enabled, as a percentage of the viewport height
-    public var scrollPastEndAmount: CGFloat = 0.5 {
+    public var overscrollAmount: CGFloat = 0.5 {
         didSet {
-            if scrollPastEnd {
+            if overscroll {
                 updateFrameIfNeeded()
             }
         }

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -114,7 +114,7 @@ public class TextView: NSView, NSTextContent {
         }
     }
 
-    /// The amount of extra space to add when scrolling past end is enabled, as a percentage of the viewport height
+    /// The amount of extra space to add when overscroll is enabled, as a percentage of the viewport height
     public var overscrollAmount: CGFloat = 0.5 {
         didSet {
             if overscroll {

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -107,19 +107,13 @@ public class TextView: NSView, NSTextContent {
         }
     }
 
-    /// Determines if the text view should allow scrolling past the end of the document
-    public var overscroll: Bool = true {
-        didSet {
-            updateFrameIfNeeded()
-        }
-    }
-
     /// The amount of extra space to add when overscroll is enabled, as a percentage of the viewport height
     public var overscrollAmount: CGFloat = 0.5 {
         didSet {
-            if overscroll {
-                updateFrameIfNeeded()
+            if overscrollAmount < 0 {
+                overscrollAmount = 0
             }
+            updateFrameIfNeeded()
         }
     }
 


### PR DESCRIPTION
### Description

Added optional functionality to allow the user to scroll past the end of the document, like in Xcode or VSCode.

### Related Issues

Closes #76 

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

This is showing an extra 50% of the available screen. It will properly update when resizing the window as well.

https://github.com/user-attachments/assets/40ef3f49-1a8b-4cad-a975-9cb9429ce32b

