### PR TITLE
Fix Text Disappearing

### DIFF
--- a/Sources/CodeEditTextView/TextLineStorage/TextLineStorage.swift
+++ b/Sources/CodeEditTextView/TextLineStorage/TextLineStorage.swift
@@ -58,6 +58,13 @@ public final class TextLineStorage<Data: Identifiable> {
 
     public init() { }
 
+    init(root: Node<Data>, count: Int, length: Int, height: CGFloat) {
+        self.root = root
+        self.count = count
+        self.length = length
+        self.height = height
+    }
+
     // MARK: - Public Methods
 
     /// Inserts a new line for the given range.
@@ -408,9 +415,9 @@ private extension TextLineStorage {
             } else {
                 transplant(nodeY, with: nodeY.right)
 
-                nodeY.right?.leftSubtreeCount = nodeY.leftSubtreeCount
-                nodeY.right?.leftSubtreeHeight = nodeY.leftSubtreeHeight
-                nodeY.right?.leftSubtreeOffset = nodeY.leftSubtreeOffset
+                nodeY.right?.leftSubtreeCount += nodeY.leftSubtreeCount
+                nodeY.right?.leftSubtreeHeight += nodeY.leftSubtreeHeight
+                nodeY.right?.leftSubtreeOffset += nodeY.leftSubtreeOffset
 
                 nodeY.right = nodeZ.right
                 nodeY.right?.parent = nodeY

--- a/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -47,6 +47,12 @@ extension TextView {
         }
 
         textStorage.endEditing()
+
+        // Cause a layout pass now that we've finished editing, if there were any edits.
+        if !ranges.isEmpty {
+            layout()
+        }
+
         if !skipUpdateSelection {
             selectionManager.notifyAfterEdit()
         }

--- a/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
+++ b/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
@@ -11,7 +11,7 @@ extension UUID: @retroactive Identifiable {
     public var id: UUID { self }
 }
 
-final class TextLayoutLineStorageTests: XCTestCase {
+final class TextLayoutLineStorageTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     /// Creates a balanced height=3 tree useful for testing and debugging.
     /// - Returns: A new tree.


### PR DESCRIPTION
### Description

Fixes two small bugs:
- When deleting a line from the line text storage, a replaced node's left subtree metadata would be replaced, instead of added to when removing that node. This caused the left subtree to be invisible in some cases, leading to broken layout.
- Force a layout pass after editing, as was the behavior before the recent layout manager changes. Fixes an issue where editing text would not move the cursor correctly.
- Adds a test case to the aforementioned line storage bug.

### Related Issues

* closes https://github.com/CodeEditApp/CodeEditSourceEditor/issues/196

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A