### PR TITLE
Fix Incorrect Copy/Paste Menu Actions

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+Menu.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Menu.swift
@@ -15,8 +15,8 @@ extension TextView {
 
         menu.items = [
             NSMenuItem(title: "Cut", action: #selector(cut(_:)), keyEquivalent: "x"),
-            NSMenuItem(title: "Copy", action: #selector(undo(_:)), keyEquivalent: "c"),
-            NSMenuItem(title: "Paste", action: #selector(undo(_:)), keyEquivalent: "v")
+            NSMenuItem(title: "Copy", action: #selector(copy(_:)), keyEquivalent: "c"),
+            NSMenuItem(title: "Paste", action: #selector(paste(_:)), keyEquivalent: "v")
         ]
 
         return menu


### PR DESCRIPTION
### Description

Fixes a typo where copy/paste menu items were incorrectly mapped to `undo`, causing their actions to trigger an undo instead of the intended action.

### Related Issues

* closes https://github.com/CodeEditApp/CodeEdit/issues/1996

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

In the example CETV app:

https://github.com/user-attachments/assets/8f3b3358-fa45-4cc2-8646-6bf28abdf158

