### PR TITLE
Share Text Storage Delegates

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+SetText.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+SetText.swift
@@ -20,6 +20,11 @@ extension TextView {
     public func setTextStorage(_ textStorage: NSTextStorage) {
         self.textStorage = textStorage
 
+        if let storageDelegate = textStorage.delegate as? MultiStorageDelegate {
+            self.storageDelegate = nil
+            self.storageDelegate = storageDelegate
+        }
+
         subviews.forEach { view in
             view.removeFromSuperview()
         }

--- a/Sources/CodeEditTextView/TextView/TextView+SetText.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+SetText.swift
@@ -21,7 +21,6 @@ extension TextView {
         self.textStorage = textStorage
 
         if let storageDelegate = textStorage.delegate as? MultiStorageDelegate {
-            self.storageDelegate = nil
             self.storageDelegate = storageDelegate
         }
 

--- a/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/Sources/CodeEditTextView/TextView/TextView.swift
@@ -320,7 +320,11 @@ public class TextView: NSView, NSTextContent {
         super.init(frame: .zero)
 
         self.emphasisManager = EmphasisManager(textView: self)
-        self.storageDelegate = MultiStorageDelegate()
+        if let storageDelegate = textStorage.delegate as? MultiStorageDelegate {
+            self.storageDelegate = storageDelegate
+        } else {
+            self.storageDelegate = MultiStorageDelegate()
+        }
 
         wantsLayer = true
         postsFrameChangedNotifications = true

--- a/Tests/CodeEditTextViewTests/TextViewTests.swift
+++ b/Tests/CodeEditTextViewTests/TextViewTests.swift
@@ -40,4 +40,28 @@ struct TextViewTests {
         // available in test module
         textView.layoutManager.lineStorage.validateInternalState()
     }
+
+    @Test
+    func sharedTextStorage() {
+        let storage = NSTextStorage(string: "Hello world")
+
+        let textView1 = TextView(string: "")
+        textView1.frame = NSRect(x: 0, y: 0, width: 100, height: 100)
+        textView1.layoutSubtreeIfNeeded()
+        textView1.setTextStorage(storage)
+
+        let textView2 = TextView(string: "")
+        textView2.frame = NSRect(x: 0, y: 0, width: 100, height: 100)
+        textView2.layoutSubtreeIfNeeded()
+        textView2.setTextStorage(storage)
+
+        // Expect both text views to receive edited events from the storage
+        #expect(textView1.layoutManager.lineCount == 1)
+        #expect(textView2.layoutManager.lineCount == 1)
+
+        storage.replaceCharacters(in: NSRange(location: 11, length: 0), with: "\nMore Lines\n")
+
+        #expect(textView1.layoutManager.lineCount == 3)
+        #expect(textView2.layoutManager.lineCount == 3)
+    }
 }


### PR DESCRIPTION
### Description

Makes the text view share the `MultiStorageDelegate` if it's already installed on the text storage object. This allows for multiple editors to completely share a storage object, receiving update events and sending them to the necessary objects without removing the other text view's objects from the shared delegate.

### Related Issues

* N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

