### PR TITLE
Don't Try to Set a Negative Frame Height

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -72,7 +72,7 @@ extension TextView {
         availableSize.height -= (scrollView?.contentInsets.top ?? 0) + (scrollView?.contentInsets.bottom ?? 0)
 
         let extraHeight = availableSize.height * overscrollAmount
-        let newHeight = max(layoutManager.estimatedHeight() + extraHeight, availableSize.height)
+        let newHeight = max(layoutManager.estimatedHeight() + extraHeight, availableSize.height, 0)
         let newWidth = layoutManager.estimatedWidth()
 
         var didUpdate = false


### PR DESCRIPTION
### Description

Fixes a potential recursion where CETV tries to set it's frame to a negative number (due to overscroll & scroll inset weirdness). This adds a super simple sanity check to make sure we limit the textview to a `0` frame at minimum.

This hang would occur when no content is present, making the content size an odd number, which also makes scroll views freak out on macOS.

### Related Issues

* https://github.com/CodeEditApp/CodeEdit/issues/2049

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A, fixes a hang.