### PR TITLE
NSBeep On Empty Undo, Remove Unnecessary Redirection

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+UndoRedo.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+UndoRedo.swift
@@ -14,7 +14,7 @@ extension TextView {
     }
 
     override public var undoManager: UndoManager? {
-        _undoManager?.manager
+        _undoManager
     }
 
     @objc func undo(_ sender: AnyObject?) {

--- a/Tests/CodeEditTextViewTests/TextViewTests.swift
+++ b/Tests/CodeEditTextViewTests/TextViewTests.swift
@@ -64,4 +64,18 @@ struct TextViewTests {
         #expect(textView1.layoutManager.lineCount == 3)
         #expect(textView2.layoutManager.lineCount == 3)
     }
+
+    @Test("Custom UndoManager class receives events")
+    func customUndoManagerReceivesEvents() {
+        let textView = TextView(string: "")
+
+        textView.replaceCharacters(in: .zero, with: "Hello World")
+        textView.undo(nil)
+
+        #expect(textView.string == "")
+
+        textView.redo(nil)
+
+        #expect(textView.string == "Hello World")
+    }
 }


### PR DESCRIPTION
### Description

- When the undo or redo stack is empty, and the user tries to undo or redo, plays the beep sound.
- Removes the (now) unnecessary `DelegatedUndoManager` type that sent messages to the `CEUndoManager` type. This was a holdover from when we did not have a custom text view.
  - Made `CEUndoManager` a subclass of `UndoManager`
  - Added more overrides to more correctly conform to the `UndoManager` class.

### Related Issues

* closes #89

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots
