### PR TITLE
Correctly Group Drag-and-drop for Undo

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+Drag.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Drag.swift
@@ -255,9 +255,9 @@ extension TextView: NSDraggingSource {
             insertText("") // Replace the selected ranges with nothing
         }
 
-        undoManager?.endUndoGrouping()
-
         replaceCharacters(in: [NSRange(location: insertionOffset, length: 0)], with: insertionString)
+
+        undoManager?.endUndoGrouping()
 
         selectionManager.setSelectedRange(
             NSRange(location: insertionOffset, length: NSString(string: insertionString).length)


### PR DESCRIPTION
### Description

Moves the `endUndoGrouping` call to the end of the actual editing operation when dropping text. Makes it so only one undo command is needed to undo a drag-and-drop operation.

### Related Issues

* closes #99

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/user-attachments/assets/35952874-6d4d-4702-b149-f06b9ffb5226


