### PR TITLE
Select Undone/Redone Text

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
@@ -14,11 +14,9 @@ extension TextView {
 
     /// Scrolls the upmost selection to the visible rect if `scrollView` is not `nil`.
     public func scrollSelectionToVisible() {
-        guard let scrollView, let selection = getSelection() else {
+        guard let scrollView else {
             return
         }
-
-        let offsetToScrollTo = offsetNotPivot(selection)
 
         // There's a bit of a chicken-and-the-egg issue going on here. We need to know the rect to scroll to, but we
         // can't know the exact rect to make visible without laying out the text. Then, once text is laid out the
@@ -26,7 +24,7 @@ extension TextView {
         // pass and scroll to that rect.
 
         var lastFrame: CGRect = .zero
-        while let boundingRect = layoutManager.rectForOffset(offsetToScrollTo), lastFrame != boundingRect {
+        while let boundingRect = getSelection()?.boundingRect, lastFrame != boundingRect {
             lastFrame = boundingRect
             layoutManager.layoutLines()
             selectionManager.updateSelectionViews()
@@ -34,6 +32,7 @@ extension TextView {
         }
         if lastFrame != .zero {
             scrollView.contentView.scrollToVisible(lastFrame)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
         }
     }
 

--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -85,6 +85,7 @@ public class CEUndoManager: UndoManager {
         textView.textStorage.endEditing()
 
         updateSelectionsForMutations(mutations: item.mutations.map { $0.mutation })
+        textView.scrollSelectionToVisible()
 
         NotificationCenter.default.post(name: .NSUndoManagerDidUndoChange, object: self)
         redoStack.append(item)
@@ -112,6 +113,7 @@ public class CEUndoManager: UndoManager {
         textView.textStorage.endEditing()
 
         updateSelectionsForMutations(mutations: item.mutations.map { $0.inverse })
+        textView.scrollSelectionToVisible()
 
         NotificationCenter.default.post(name: .NSUndoManagerDidRedoChange, object: self)
         undoStack.append(item)

--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -83,6 +83,9 @@ public class CEUndoManager: UndoManager {
             textView.replaceCharacters(in: mutation.inverse.range, with: mutation.inverse.string)
         }
         textView.textStorage.endEditing()
+
+        updateSelectionsForMutations(mutations: item.mutations.map { $0.mutation })
+
         NotificationCenter.default.post(name: .NSUndoManagerDidUndoChange, object: self)
         redoStack.append(item)
         _isUndoing = false
@@ -101,14 +104,34 @@ public class CEUndoManager: UndoManager {
 
         _isRedoing = true
         NotificationCenter.default.post(name: .NSUndoManagerWillRedoChange, object: self)
+        textView.selectionManager.removeCursors()
         textView.textStorage.beginEditing()
         for mutation in item.mutations {
             textView.replaceCharacters(in: mutation.mutation.range, with: mutation.mutation.string)
         }
         textView.textStorage.endEditing()
+
+        updateSelectionsForMutations(mutations: item.mutations.map { $0.inverse })
+
         NotificationCenter.default.post(name: .NSUndoManagerDidRedoChange, object: self)
         undoStack.append(item)
         _isRedoing = false
+    }
+
+    /// We often undo/redo a group of mutations that contain updated ranges that are next to each other but for a user
+    /// should be one continuous range. This merges those ranges into a set of disjoint ranges before updating the
+    /// selection manager.
+    private func updateSelectionsForMutations(mutations: [TextMutation]) {
+        if mutations.reduce(0, { $0 + $1.range.length }) == 0, let last = mutations.last {
+            // If the mutations are only deleting text (no replacement), we just place the cursor at the last range,
+            // since all the ranges are the same but the other method will return no ranges (empty range).
+            textView?.selectionManager.setSelectedRange(last.range)
+        } else {
+            let mergedRanges = mutations.reduce(into: IndexSet(), { set, mutation in
+                set.insert(range: mutation.range)
+            })
+            textView?.selectionManager.setSelectedRanges(mergedRanges.rangeView.map { NSRange($0) })
+        }
     }
 
     /// Clears the undo/redo stacks.

--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -122,10 +122,14 @@ public class CEUndoManager: UndoManager {
     /// should be one continuous range. This merges those ranges into a set of disjoint ranges before updating the
     /// selection manager.
     private func updateSelectionsForMutations(mutations: [TextMutation]) {
-        if mutations.reduce(0, { $0 + $1.range.length }) == 0, let last = mutations.last {
-            // If the mutations are only deleting text (no replacement), we just place the cursor at the last range,
-            // since all the ranges are the same but the other method will return no ranges (empty range).
-            textView?.selectionManager.setSelectedRange(last.range)
+        if mutations.reduce(0, { $0 + $1.range.length }) == 0 {
+            if let minimumMutation = mutations.min(by: { $0.range.location < $1.range.location }) {
+                // If the mutations are only deleting text (no replacement), we just place the cursor at the last range,
+                // since all the ranges are the same but the other method will return no ranges (empty range).
+                textView?.selectionManager.setSelectedRange(
+                    NSRange(location: minimumMutation.range.location, length: 0)
+                )
+            }
         } else {
             let mergedRanges = mutations.reduce(into: IndexSet(), { set, mutation in
                 set.insert(range: mutation.range)


### PR DESCRIPTION
### Description

Updates the undo manager to update the text selection when undoing/redoing.

Two cases:
- Replaced/Inserted text - selects the inserted text
- Deleted text - Places cursor at the start of the deleted text, as if the user had just deleted it.

### Related Issues

* closes #95

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots


https://github.com/user-attachments/assets/55309316-9106-4ce2-ac25-952e2addbbfe

