### PR TITLE
Track Mouse Drag Outside View

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
@@ -206,41 +206,6 @@ extension TextView {
     }
 
     private func dragColumnSelection(mouseDragAnchor: CGPoint, locationInView: CGPoint) {
-        // Drag the selection and select in columns
-        let start = CGPoint(
-            x: min(mouseDragAnchor.x, locationInView.x),
-            y: min(mouseDragAnchor.y, locationInView.y)
-        )
-        let end = CGPoint(
-            x: max(mouseDragAnchor.x, locationInView.x),
-            y: max(mouseDragAnchor.y, locationInView.y)
-        )
-
-        // Collect all overlapping text ranges
-        var selectedRanges: [NSRange] = layoutManager.linesStartingAt(start.y, until: end.y).flatMap { textLine in
-            // Collect fragment ranges
-            return textLine.data.lineFragments.compactMap { lineFragment -> NSRange? in
-                let startOffset = self.layoutManager.textOffsetAtPoint(
-                    start,
-                    fragmentPosition: lineFragment,
-                    linePosition: textLine
-                )
-                let endOffset = self.layoutManager.textOffsetAtPoint(
-                    end,
-                    fragmentPosition: lineFragment,
-                    linePosition: textLine
-                )
-                guard let startOffset, let endOffset else { return nil }
-
-                return NSRange(start: startOffset, end: endOffset)
-            }
-        }
-
-        // If we have some non-cursor selections, filter out any cursor selections
-        if selectedRanges.contains(where: { !$0.isEmpty }) {
-            selectedRanges = selectedRanges.filter({ !$0.isEmpty })
-        }
-
-        selectionManager.setSelectedRanges(selectedRanges)
+        selectColumns(betweenPointA: mouseDragAnchor, pointB: locationInView)
     }
 }


### PR DESCRIPTION
### Description

Fixes a bug that didn't allow the view to track drags outside it's bounds. Users can now drag selections over other views and outside the window.

### Related Issues

* closes #100
* closes https://github.com/CodeEditApp/CodeEditSourceEditor/issues/316

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

https://github.com/user-attachments/assets/ffbad5bf-5a56-4ef8-91f7-c5a9bb725208

