### PR TITLE
Fix Cursor Lagging - Update Cursors in `TextView.layout`

### DIFF
--- a/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -11,6 +11,7 @@ extension TextView {
     override public func layout() {
         super.layout()
         layoutManager.layoutLines()
+        selectionManager.updateSelectionViews(skipTimerReset: true)
     }
 
     open override class var isCompatibleWithResponsiveScrolling: Bool {


### PR DESCRIPTION
### Description

Addresses an issue described by @nkleemann in the linked issue. The issue was a bug where cursors would lag behind an edit. This is due to the edited line's layout information being invalidated by the edit, meaning the selection manager cannot get valid layout information to position cursors.

This change puts a selection position update in the text view's `layout` call, after the layout manager has done it's layout pass. This ensures the selection manage is using valid layout information, fixing the lagging issue.

### Related Issues

* https://github.com/CodeEditApp/CodeEditSourceEditor/issues/317

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

On v0.11.2:

https://github.com/user-attachments/assets/f4f23e02-58e5-410b-ba1a-0ea5e449dce4

With this change:

https://github.com/user-attachments/assets/663fdecb-c1dd-43ec-9990-5f8c7da07205


