### PR TITLE
Add Text Attachment Actions

### DIFF
--- a/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachment.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachment.swift
@@ -7,11 +7,29 @@
 
 import AppKit
 
+public enum TextAttachmentAction {
+    /// Perform no action.
+    case none
+    /// Replace the attachment range with the given string.
+    case replace(text: String)
+    /// Discard the attachment and perform no other action, this is the default action.
+    case discard
+}
+
 /// Represents an attachment type. Attachments take up some set width, and draw their contents in a receiver view.
 public protocol TextAttachment: AnyObject {
     var width: CGFloat { get }
     var isSelected: Bool { get set }
+
     func draw(in context: CGContext, rect: NSRect)
+
+    /// The action that should be performed when this attachment is invoked (double-click, enter pressed).
+    /// This method is optional, by default the attachment is discarded.
+    func attachmentAction() -> TextAttachmentAction
+}
+
+public extension TextAttachment {
+    func attachmentAction() -> TextAttachmentAction { .discard }
 }
 
 /// Type-erasing type for ``TextAttachment`` that also contains range information about the attachment.

--- a/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachmentManager.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachmentManager.swift
@@ -102,7 +102,7 @@ public final class TextAttachmentManager {
     /// - Returns: An array of `AnyTextAttachment` instances whose ranges intersect `query`.
     public func getAttachmentsOverlapping(_ range: NSRange) -> [AnyTextAttachment] {
         // Find the first attachment whose end is beyond the start of the query.
-        guard let startIdx = firstIndex(where: { $0.range.upperBound >= range.location }) else {
+        guard let startIdx = orderedAttachments.firstIndex(where: { $0.range.upperBound >= range.location }) else {
             return []
         }
 

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
@@ -339,4 +339,12 @@ extension TextLayoutManager {
             height: lineFragment.scaledHeight
         ).pixelAligned
     }
+
+    func contentRun(at offset: Int) -> LineFragment.FragmentContent? {
+        guard let textLine = textLineForOffset(offset),
+              let fragment = textLine.data.lineFragments.getLine(atOffset: offset - textLine.range.location) else {
+            return nil
+        }
+        return fragment.data.findContent(at: offset - textLine.range.location - fragment.range.location)?.content
+    }
 }

--- a/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -80,7 +80,6 @@ public class TextSelectionManager: NSObject {
         textSelections = [selection]
         updateSelectionViews()
         NotificationCenter.default.post(Notification(name: Self.selectionChangedNotification, object: self))
-        delegate?.setNeedsDisplay()
     }
 
     /// Set the selected ranges to new ranges. Overrides any existing selections.

--- a/Sources/CodeEditTextView/TextView/TextView+Insert.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Insert.swift
@@ -9,6 +9,21 @@ import AppKit
 
 extension TextView {
     override public func insertNewline(_ sender: Any?) {
+        var attachments: [AnyTextAttachment] = selectionManager.textSelections.compactMap({ selection in
+            let content = layoutManager.contentRun(at: selection.range.location)
+            if case let .attachment(attachment) = content?.data, attachment.range == selection.range {
+                return attachment
+            }
+            return nil
+        })
+
+        if !attachments.isEmpty {
+            for attachment in attachments.sorted(by: { $0.range.location > $1.range.location }) {
+                performAttachmentAction(attachment: attachment)
+            }
+            return
+        }
+
         insertText(layoutManager.detectedLineEnding.rawValue)
     }
 

--- a/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
@@ -87,18 +87,22 @@ extension TextView {
         case 1:
             selectionManager.setSelectedRange(attachment.range)
         case 2:
-            let action = attachment.attachment.attachmentAction()
-            switch action {
-            case .none:
-                return
-            case .discard:
-                layoutManager.attachments.remove(atOffset: offset)
-                selectionManager.setSelectedRange(NSRange(location: attachment.range.location, length: 0))
-            case let .replace(text):
-                replaceCharacters(in: attachment.range, with: text)
-            }
+            performAttachmentAction(attachment: attachment)
         default:
             break
+        }
+    }
+
+    func performAttachmentAction(attachment: AnyTextAttachment) {
+        let action = attachment.attachment.attachmentAction()
+        switch action {
+        case .none:
+            return
+        case .discard:
+            layoutManager.attachments.remove(atOffset: attachment.range.location)
+            selectionManager.setSelectedRange(NSRange(location: attachment.range.location, length: 0))
+        case let .replace(text):
+            replaceCharacters(in: attachment.range, with: text)
         }
     }
 


### PR DESCRIPTION
### Description

Adds actions to text attachments. Actions are performed in either of the following:
- A selection's range exactly matches that of the attachment, and the enter key is pressed.
  - For multiple cursors, if any selections match, the action is taken on all matching selections and other behaviors are ignored.
- An attachment is double-clicked.

Attachments can return an action enum to indicate what the textview should do when the action is invoked. This allows for attachments to let the textview handle some common cases like discarding the attachment or replacing it with text, and allows attachments to perform their own logic at the same time.

### Related Issues

* https://github.com/CodeEditApp/CodeEditSourceEditor/issues/43

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Example in CodeEdit's folding attachments.

https://github.com/user-attachments/assets/1bd670b4-08ed-463e-8f06-8b2fff7e0cbb

