### PR TITLE
Skip Selection Update in Undo/Redo

### DIFF
--- a/Sources/CodeEditTextView/Utils/CEUndoManager.swift
+++ b/Sources/CodeEditTextView/Utils/CEUndoManager.swift
@@ -80,7 +80,11 @@ public class CEUndoManager: UndoManager {
         NotificationCenter.default.post(name: .NSUndoManagerWillUndoChange, object: self)
         textView.textStorage.beginEditing()
         for mutation in item.mutations.reversed() {
-            textView.replaceCharacters(in: mutation.inverse.range, with: mutation.inverse.string)
+            textView.replaceCharacters(
+                in: mutation.inverse.range,
+                with: mutation.inverse.string,
+                skipUpdateSelection: true
+            )
         }
         textView.textStorage.endEditing()
 
@@ -108,7 +112,11 @@ public class CEUndoManager: UndoManager {
         textView.selectionManager.removeCursors()
         textView.textStorage.beginEditing()
         for mutation in item.mutations {
-            textView.replaceCharacters(in: mutation.mutation.range, with: mutation.mutation.string)
+            textView.replaceCharacters(
+                in: mutation.mutation.range,
+                with: mutation.mutation.string,
+                skipUpdateSelection: true
+            )
         }
         textView.textStorage.endEditing()
 


### PR DESCRIPTION
### Description

Skips updating the selection when performing undo/redo.

### Related Issues

N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A
