### PR TITLE
Layout Invalidation Performance

### DIFF
--- a/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+translate.swift
+++ b/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+translate.swift
@@ -1,0 +1,14 @@
+//
+//  NSRange+translate.swift
+//  CodeEditTextView
+//
+//  Created by Khan Winter on 7/21/25.
+//
+
+import Foundation
+
+extension NSRange {
+    func translate(location: Int) -> NSRange {
+        NSRange(location: self.location + location, length: length)
+    }
+}

--- a/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
+++ b/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
@@ -112,12 +112,13 @@ extension TextLayoutManager {
         fragmentPosition: TextLineStorage<LineFragment>.TextLinePosition,
         in linePosition: TextLineStorage<TextLine>.TextLinePosition
     ) -> Int? {
-        let endPosition = fragmentPosition.data.documentRange.max
+        let fragmentRange = fragmentPosition.range.translate(location: linePosition.range.location)
+        let endPosition = fragmentRange.max
 
         // If the endPosition is at the end of the line, and the line ends with a line ending character
         // return the index before the eol.
         if fragmentPosition.index == linePosition.data.lineFragments.count - 1,
-           let lineEnding = LineEnding(line: textStorage?.substring(from: fragmentPosition.data.documentRange) ?? "") {
+           let lineEnding = LineEnding(line: textStorage?.substring(from: fragmentRange) ?? "") {
             return endPosition - lineEnding.length
         } else if fragmentPosition.index != linePosition.data.lineFragments.count - 1 {
             // If this isn't the last fragment, we want to place the cursor at the offset right before the break
@@ -175,7 +176,7 @@ extension TextLayoutManager {
         guard let fragmentPosition = linePosition.data.typesetter.lineFragments.getLine(
             atOffset: offset - linePosition.range.location
         ) else {
-            return nil
+            return CGRect(x: edgeInsets.left, y: linePosition.yPos, width: 0, height: linePosition.height)
         }
 
         // Get the *real* length of the character at the offset. If this is a surrogate pair it'll return the correct
@@ -190,11 +191,11 @@ extension TextLayoutManager {
 
         let minXPos = characterXPosition(
             in: fragmentPosition.data,
-            for: realRange.location - fragmentPosition.data.documentRange.location
+            for: realRange.location - linePosition.range.location - fragmentPosition.range.location
         )
         let maxXPos = characterXPosition(
             in: fragmentPosition.data,
-            for: realRange.max - fragmentPosition.data.documentRange.location
+            for: realRange.max - linePosition.range.location - fragmentPosition.range.location
         )
 
         return CGRect(

--- a/Sources/CodeEditTextView/TextLine/LineFragment.swift
+++ b/Sources/CodeEditTextView/TextLine/LineFragment.swift
@@ -47,8 +47,7 @@ public final class LineFragment: Identifiable, Equatable {
     }
 
     public let id = UUID()
-    public let lineRange: NSRange
-    public let documentRange: NSRange
+    public var documentRange: NSRange = .notFound
     public var contents: [FragmentContent]
     public var width: CGFloat
     public var height: CGFloat
@@ -61,16 +60,12 @@ public final class LineFragment: Identifiable, Equatable {
     }
 
     init(
-        lineRange: NSRange,
-        documentRange: NSRange,
         contents: [FragmentContent],
         width: CGFloat,
         height: CGFloat,
         descent: CGFloat,
         lineHeightMultiplier: CGFloat
     ) {
-        self.lineRange = lineRange
-        self.documentRange = documentRange
         self.contents = contents
         self.width = width
         self.height = height

--- a/Sources/CodeEditTextView/TextLine/LineFragmentRenderer.swift
+++ b/Sources/CodeEditTextView/TextLine/LineFragmentRenderer.swift
@@ -122,7 +122,7 @@ public final class LineFragmentRenderer {
             context: context
         )
 
-        let range = createTextRange(for: drawingContext)
+        let range = createTextRange(for: drawingContext).clamped(to: (textStorage.string as NSString).length)
         let string = (textStorage.string as NSString).substring(with: range)
 
         processInvisibleCharacters(
@@ -177,7 +177,7 @@ public final class LineFragmentRenderer {
         guard let style = delegate.invisibleStyle(
             for: character,
             at: NSRange(start: range.location + index, end: range.max),
-            lineRange: drawingContext.lineFragment.lineRange
+            lineRange: drawingContext.lineFragment.documentRange
         ) else {
             return
         }

--- a/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
+++ b/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
@@ -79,7 +79,7 @@ open class LineFragmentView: NSView {
 
     /// Set a new line fragment for this view, updating view size.
     /// - Parameter newFragment: The new fragment to use.
-    open func setLineFragment(_ newFragment: LineFragment, renderer: LineFragmentRenderer) {
+    open func setLineFragment(_ newFragment: LineFragment, fragmentRange: NSRange, renderer: LineFragmentRenderer) {
         self.lineFragment = newFragment
         self.renderer = renderer
         self.frame.size = CGSize(width: newFragment.width, height: newFragment.scaledHeight)

--- a/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
+++ b/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
@@ -35,23 +35,19 @@ open class LineFragmentView: NSView {
     }
 
 #if DEBUG_LINE_INVALIDATION
-    /// Setup background animation from random color to clear
+    /// Setup background animation from random color to clear when this fragment is invalidated.
     private func setupBackgroundAnimation() {
-        // Ensure the view is layer-backed for animation
         self.wantsLayer = true
 
-        // Generate random color
         let randomColor = NSColor(
             red: CGFloat.random(in: 0...1),
             green: CGFloat.random(in: 0...1),
             blue: CGFloat.random(in: 0...1),
-            alpha: 0.3 // Start with some transparency
+            alpha: 0.3
         )
 
-        // Set initial background color
         self.layer?.backgroundColor = randomColor.cgColor
 
-        // Create animation from random color to clear
         let animation = CABasicAnimation(keyPath: "backgroundColor")
         animation.fromValue = randomColor.cgColor
         animation.toValue = NSColor.clear.cgColor
@@ -59,11 +55,8 @@ open class LineFragmentView: NSView {
         animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
         animation.fillMode = .forwards
         animation.isRemovedOnCompletion = false
-
-        // Apply animation
         self.layer?.add(animation, forKey: "backgroundColorAnimation")
 
-        // Set final state
         DispatchQueue.main.asyncAfter(deadline: .now() + animation.duration) {
             self.layer?.backgroundColor = NSColor.clear.cgColor
         }

--- a/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
+++ b/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
@@ -11,7 +11,9 @@ import AppKit
 open class LineFragmentView: NSView {
     public weak var lineFragment: LineFragment?
     public weak var renderer: LineFragmentRenderer?
+#if DEBUG_LINE_INVALIDATION
     private var backgroundAnimation: CABasicAnimation?
+#endif
 
     open override var isFlipped: Bool {
         true
@@ -26,14 +28,13 @@ open class LineFragmentView: NSView {
     /// Initialize with random background color animation
     public override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        setupBackgroundAnimation()
     }
 
     required public init?(coder: NSCoder) {
         super.init(coder: coder)
-        setupBackgroundAnimation()
     }
 
+#if DEBUG_LINE_INVALIDATION
     /// Setup background animation from random color to clear
     private func setupBackgroundAnimation() {
         // Ensure the view is layer-backed for animation
@@ -67,14 +68,16 @@ open class LineFragmentView: NSView {
             self.layer?.backgroundColor = NSColor.clear.cgColor
         }
     }
+#endif
 
     /// Prepare the view for reuse, clears the line fragment reference and restarts animation.
     open override func prepareForReuse() {
         super.prepareForReuse()
         lineFragment = nil
 
-        // Restart the background animation
+#if DEBUG_LINE_INVALIDATION
         setupBackgroundAnimation()
+#endif
     }
 
     /// Set a new line fragment for this view, updating view size.

--- a/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
+++ b/Sources/CodeEditTextView/TextLine/LineFragmentView.swift
@@ -11,6 +11,7 @@ import AppKit
 open class LineFragmentView: NSView {
     public weak var lineFragment: LineFragment?
     public weak var renderer: LineFragmentRenderer?
+    private var backgroundAnimation: CABasicAnimation?
 
     open override var isFlipped: Bool {
         true
@@ -22,10 +23,58 @@ open class LineFragmentView: NSView {
 
     open override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
-    /// Prepare the view for reuse, clears the line fragment reference.
+    /// Initialize with random background color animation
+    public override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupBackgroundAnimation()
+    }
+
+    required public init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupBackgroundAnimation()
+    }
+
+    /// Setup background animation from random color to clear
+    private func setupBackgroundAnimation() {
+        // Ensure the view is layer-backed for animation
+        self.wantsLayer = true
+
+        // Generate random color
+        let randomColor = NSColor(
+            red: CGFloat.random(in: 0...1),
+            green: CGFloat.random(in: 0...1),
+            blue: CGFloat.random(in: 0...1),
+            alpha: 0.3 // Start with some transparency
+        )
+
+        // Set initial background color
+        self.layer?.backgroundColor = randomColor.cgColor
+
+        // Create animation from random color to clear
+        let animation = CABasicAnimation(keyPath: "backgroundColor")
+        animation.fromValue = randomColor.cgColor
+        animation.toValue = NSColor.clear.cgColor
+        animation.duration = 1.0
+        animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+        animation.fillMode = .forwards
+        animation.isRemovedOnCompletion = false
+
+        // Apply animation
+        self.layer?.add(animation, forKey: "backgroundColorAnimation")
+
+        // Set final state
+        DispatchQueue.main.asyncAfter(deadline: .now() + animation.duration) {
+            self.layer?.backgroundColor = NSColor.clear.cgColor
+        }
+    }
+
+    /// Prepare the view for reuse, clears the line fragment reference and restarts animation.
     open override func prepareForReuse() {
         super.prepareForReuse()
         lineFragment = nil
+
+        // Restart the background animation
+        setupBackgroundAnimation()
     }
 
     /// Set a new line fragment for this view, updating view size.

--- a/Sources/CodeEditTextView/TextLine/TextLine.swift
+++ b/Sources/CodeEditTextView/TextLine/TextLine.swift
@@ -31,13 +31,11 @@ public final class TextLine: Identifiable, Equatable {
     /// - Returns: True, if this line has been marked as needing layout using ``TextLine/setNeedsLayout()`` or if the
     ///            line needs to find new line breaks due to a new constraining width.
     func needsLayout(maxWidth: CGFloat) -> Bool {
-        needsLayout // Force layout
+        return needsLayout // Force layout
         || (
             // Both max widths we're comparing are finite
             maxWidth.isFinite
             && (self.maxWidth ?? 0.0).isFinite
-            // We can't use `<` here because we want to calculate layout again if this was previously constrained to a
-            // small layout size and needs to grow.
             && maxWidth != (self.maxWidth ?? 0.0)
         )
     }
@@ -57,14 +55,15 @@ public final class TextLine: Identifiable, Equatable {
         attachments: [AnyTextAttachment]
     ) {
         let string = stringRef.attributedSubstring(from: range)
-        self.maxWidth = displayData.maxWidth
-        typesetter.typeset(
+        let maxWidth = typesetter.typeset(
             string,
             documentRange: range,
             displayData: displayData,
             markedRanges: markedRanges,
             attachments: attachments
         )
+//        self.maxWidth = min(maxWidth, displayData.maxWidth)
+        self.maxWidth = displayData.maxWidth
         needsLayout = false
     }
 

--- a/Sources/CodeEditTextView/TextLine/TextLine.swift
+++ b/Sources/CodeEditTextView/TextLine/TextLine.swift
@@ -62,7 +62,6 @@ public final class TextLine: Identifiable, Equatable {
             markedRanges: markedRanges,
             attachments: attachments
         )
-//        self.maxWidth = min(maxWidth, displayData.maxWidth)
         self.maxWidth = displayData.maxWidth
         needsLayout = false
     }

--- a/Sources/CodeEditTextView/TextLine/Typesetter/TypesetContext.swift
+++ b/Sources/CodeEditTextView/TextLine/Typesetter/TypesetContext.swift
@@ -16,6 +16,7 @@ struct TypesetContext {
     /// Accumulated generated line fragments.
     var lines: [TextLineStorage<LineFragment>.BuildItem] = []
     var maxHeight: CGFloat = 0
+    var maxWidth: CGFloat = 0
     /// The current fragment typesetting context.
     var fragmentContext = LineFragmentTypesetContext(start: 0, width: 0.0, height: 0.0, descent: 0.0)
 
@@ -76,6 +77,7 @@ struct TypesetContext {
             .init(data: fragment, length: currentPosition - fragmentContext.start, height: fragment.scaledHeight)
         )
         maxHeight = max(maxHeight, fragment.scaledHeight)
+        maxWidth = max(maxWidth, fragment.width)
 
         fragmentContext.clear()
         fragmentContext.start = currentPosition

--- a/Sources/CodeEditTextView/TextLine/Typesetter/TypesetContext.swift
+++ b/Sources/CodeEditTextView/TextLine/Typesetter/TypesetContext.swift
@@ -16,7 +16,6 @@ struct TypesetContext {
     /// Accumulated generated line fragments.
     var lines: [TextLineStorage<LineFragment>.BuildItem] = []
     var maxHeight: CGFloat = 0
-    var maxWidth: CGFloat = 0
     /// The current fragment typesetting context.
     var fragmentContext = LineFragmentTypesetContext(start: 0, width: 0.0, height: 0.0, descent: 0.0)
 
@@ -62,11 +61,6 @@ struct TypesetContext {
     /// Pop the current fragment state into a new line fragment, and reset the fragment state.
     mutating func popCurrentData() {
         let fragment = LineFragment(
-            lineRange: documentRange,
-            documentRange: NSRange(
-                location: fragmentContext.start + documentRange.location,
-                length: currentPosition - fragmentContext.start
-            ),
             contents: fragmentContext.contents,
             width: fragmentContext.width,
             height: fragmentContext.height,
@@ -77,7 +71,6 @@ struct TypesetContext {
             .init(data: fragment, length: currentPosition - fragmentContext.start, height: fragment.scaledHeight)
         )
         maxHeight = max(maxHeight, fragment.scaledHeight)
-        maxWidth = max(maxWidth, fragment.width)
 
         fragmentContext.clear()
         fragmentContext.start = currentPosition

--- a/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
+++ b/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
@@ -29,10 +29,11 @@ extension TextView {
             layoutManager.layoutLines()
             selectionManager.updateSelectionViews()
             selectionManager.drawSelections(in: visibleRect)
-        }
-        if lastFrame != .zero {
-            scrollView.contentView.scrollToVisible(lastFrame)
-            scrollView.reflectScrolledClipView(scrollView.contentView)
+
+            if lastFrame != .zero {
+                scrollView.contentView.scrollToVisible(lastFrame)
+                scrollView.reflectScrolledClipView(scrollView.contentView)
+            }
         }
     }
 

--- a/Sources/CodeEditTextView/Utils/ViewReuseQueue.swift
+++ b/Sources/CodeEditTextView/Utils/ViewReuseQueue.swift
@@ -40,6 +40,10 @@ public class ViewReuseQueue<View: NSView, Key: Hashable> {
         return view
     }
 
+    public func getView(forKey key: Key) -> View? {
+        usedViews[key]
+    }
+
     /// Removes a view for the given key and enqueues it for reuse.
     /// - Parameter key: The key for the view to reuse.
     public func enqueueView(forKey key: Key) {


### PR DESCRIPTION
### Description

- Added a new debug mode for visualizing line fragment invalidation.
- Adjusted the layout pass to avoid typesetting lines that don't need layout.
  - Made a distinction between 'forced layout' via `setNeedsLayout` and 'continued' layout where a line previously scanned in the layout pass was updated.
  - Due to that, I was able to check if a line fragment actually needed typesetting or just potentially needed to have it's position adjusted.
  - Added a new method to update a line's view's positions during layout.
- Removed the unnecessary `lineRange` variable on the `LineFragment` class.
- Adjusted the use of `documentRange` on the `LineFragment` class. It's now updated during layout, simplifying various methods.

### Related Issues

* N/A

### Checklist

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

Before:

https://github.com/user-attachments/assets/05027712-5690-4970-b1ab-e0b4fe9553ec

After:

https://github.com/user-attachments/assets/36350ea1-66d8-43d0-a676-1bb770a733d7
