### PR TITLE
Fix Word Duplication at Wrap Boundaries

### DIFF
--- a/Sources/CodeEditTextView/TextLine/Typesetter/Typesetter.swift
+++ b/Sources/CodeEditTextView/TextLine/Typesetter/Typesetter.swift
@@ -181,7 +181,8 @@ final public class Typesetter {
             )
 
             // Indicates the subrange on the range that the typesetter knows about. This may not be the entire line
-            let typesetSubrange = NSRange(location: context.currentPosition - range.location, length: lineBreak)
+            let startOffset = context.currentPosition - range.location
+            let typesetSubrange = NSRange(location: startOffset, length: lineBreak - startOffset)
             let typesetData = typesetLine(typesetter: typesetter, range: typesetSubrange)
 
             // The typesetter won't tell us if 0 characters can fit in the constrained space. This checks to

--- a/Sources/CodeEditTextView/TextLine/Typesetter/Typesetter.swift
+++ b/Sources/CodeEditTextView/TextLine/Typesetter/Typesetter.swift
@@ -181,6 +181,7 @@ final public class Typesetter {
             )
 
             // Indicates the subrange on the range that the typesetter knows about. This may not be the entire line
+            // Convert the absolute position to an offset relative to the typesetter's range.
             let startOffset = context.currentPosition - range.location
             let typesetSubrange = NSRange(location: startOffset, length: lineBreak - startOffset)
             let typesetData = typesetLine(typesetter: typesetter, range: typesetSubrange)


### PR DESCRIPTION
### Description

When a long line wraps, words at the wrap boundary get duplicated — appearing at the end of one visual line and again at the start of the next.

`suggestLineBreak` returns a position in the string, but it was passed directly as a length to `NSRange`. On the first fragment this works by coincidence (position equals length when starting at 0), but on subsequent fragments the length is too large by `startOffset`, causing each CTLine to include characters already rendered in the previous fragment.

### Related Issues

* https://github.com/CodeEditApp/CodeEditSourceEditor/issues/367

### Checklist

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

| Before | After |
|--------|--------|
| <img width="1962" height="1124" alt="before" src="https://github.com/user-attachments/assets/7780334f-3a04-42c4-ae6b-4e330c305370" /> | <img width="1956" height="1124" alt="after" src="https://github.com/user-attachments/assets/da8cf93a-5054-4b6d-a969-16f55ea2e138" /> | 

